### PR TITLE
Fix warnings for class names

### DIFF
--- a/blender_bindings/operators/flex_operators.py
+++ b/blender_bindings/operators/flex_operators.py
@@ -173,8 +173,8 @@ class SourceIO_PG_FlexController(bpy.types.PropertyGroup):
 
 class SOURCEIO_PT_FlexControlPanel(UITools, bpy.types.Panel):
     bl_label = 'Flex controllers'
-    bl_idname = 'sourceio.flex_control_panel'
-    bl_parent_id = "sourceio.utils"
+    bl_idname = 'SOURCEIO_PT_FlexControlPanel'
+    bl_parent_id = "SOURCEIO_PT_Utils"
 
     @classmethod
     def poll(cls, context):
@@ -184,12 +184,12 @@ class SOURCEIO_PT_FlexControlPanel(UITools, bpy.types.Panel):
 
     def draw(self, context):
         obj = context.active_object  # type:bpy.types.Object
-        self.layout.template_list("SourceIO_UL_FlexControllerList", "",
+        self.layout.template_list("SOURCEIO_UL_FlexControllerList", "",
                                   obj.data, "flex_controllers",
                                   obj.data, "flex_selected_index")
 
 
-class SourceIO_UL_FlexControllerList(bpy.types.UIList):
+class SOURCEIO_UL_FlexControllerList(bpy.types.UIList):
     def draw_item(self, context, layout, data, item, icon, active_data, active_propname):
         operator = data
         controller_entry: SourceIO_PG_FlexController = item
@@ -203,6 +203,6 @@ class SourceIO_UL_FlexControllerList(bpy.types.UIList):
 
 classes = (
     SourceIO_PG_FlexController,
-    SourceIO_UL_FlexControllerList,
+    SOURCEIO_UL_FlexControllerList,
     SOURCEIO_PT_FlexControlPanel,
 )

--- a/blender_bindings/operators/shared_operators.py
+++ b/blender_bindings/operators/shared_operators.py
@@ -238,7 +238,7 @@ class UITools:
 
 class SOURCEIO_PT_Utils(UITools, bpy.types.Panel):
     bl_label = "SourceIO utils"
-    bl_idname = "sourceio.utils"
+    bl_idname = "SOURCEIO_PT_Utils"
 
     def draw(self, context):
         pass
@@ -252,8 +252,8 @@ class SOURCEIO_PT_Utils(UITools, bpy.types.Panel):
 
 class SOURCEIO_PT_Placeholders(UITools, bpy.types.Panel):
     bl_label = 'Placeholders loading'
-    bl_idname = 'sourceio.placeholders'
-    bl_parent_id = "sourceio.utils"
+    bl_idname = 'SOURCEIO_PT_Placeholders'
+    bl_parent_id = "SOURCEIO_PT_Utils"
 
     @classmethod
     def poll(cls, context):
@@ -283,8 +283,8 @@ class SOURCEIO_PT_Placeholders(UITools, bpy.types.Panel):
 
 class SOURCEIO_PT_SkinChanger(UITools, bpy.types.Panel):
     bl_label = 'Model skins'
-    bl_idname = 'sourceio.skin_changer'
-    bl_parent_id = "sourceio.utils"
+    bl_idname = 'SOURCEIO_PT_SkinChanger'
+    bl_parent_id = "SOURCEIO_PT_Utils"
 
     @classmethod
     def poll(cls, context):

--- a/blender_bindings/operators/vpk_operators.py
+++ b/blender_bindings/operators/vpk_operators.py
@@ -137,7 +137,7 @@ class SourceIO_OP_VPKBrowser(bpy.types.Operator):
                 entry.name = directory
 
             self.selected_index = -1
-        file_view.template_list("SourceIO_UL_VPKDirList", "", self, "current_dir", self, "selected_index")
+        file_view.template_list("SOURCEIO_UL_VPKDirList", "", self, "current_dir", self, "selected_index")
 
         props_col = main_col.column()
         props_box = props_col.box()
@@ -151,7 +151,7 @@ class SourceIO_OP_VPKBrowser(bpy.types.Operator):
 
 
 # noinspection PyPep8Naming
-class SourceIO_UL_VPKDirList(bpy.types.UIList):
+class SOURCEIO_UL_VPKDirList(bpy.types.UIList):
     def draw_item(self, context, layout, data, item, icon, active_data, active_propname):
         operator = data
         vpk_entry = item
@@ -171,6 +171,6 @@ classes = (
     SourceIO_PG_VPKEntry,
     SourceIO_OP_VPKButtonUp,
     SourceIO_OP_VPKBrowserLoader,
-    SourceIO_UL_VPKDirList,
+    SOURCEIO_UL_VPKDirList,
     SourceIO_OP_VPKBrowser,
 )


### PR DESCRIPTION
Removes the following warnings from the console:
Warning: 'sourceio.utils' does not contain '_PT_' with prefix and suffix
Warning: 'sourceio.placeholders' does not contain '_PT_' with prefix and suffix
Warning: 'sourceio.skin_changer' does not contain '_PT_' with prefix and suffix
Warning: 'SourceIO_UL_VPKDirList' doesn't have upper case alpha-numeric prefix
Warning: 'SourceIO_UL_FlexControllerList' doesn't have upper case alpha-numeric prefix
Warning: 'sourceio.flex_control_panel' does not contain '_PT_' with prefix and suffix