### PR TITLE
Support vectors without commas

### DIFF
--- a/library/source1/vmt/__init__.py
+++ b/library/source1/vmt/__init__.py
@@ -59,6 +59,8 @@ class VMT:
             pass
         elif raw_value[0] == '[':
             converter = float
+        elif len(raw_value.split()) > 1:
+            return tuple(map(float, raw_value.split())), float
         else:
             return [float(raw_value)], float
             # raise ValueError(f'Not a vector value: {raw_value}')


### PR DESCRIPTION
Before, if a material is written without commas, it would for example input float("1.0 1.0 1.0"), resulting in an error.