### PR TITLE
Source1 Material Loader Overhaul

### DIFF
--- a/blender_bindings/material_loader/shaders/source1_shader_base.py
+++ b/blender_bindings/material_loader/shaders/source1_shader_base.py
@@ -22,12 +22,6 @@ class Source1ShaderBase(ShaderBase):
         if image is not None:
             return image
 
-        for image in bpy.data.images:
-            if (fp := image.get('full_path')) == None: continue
-            if fp == (texture_path / texture_name).as_posix().lower():
-                self.logger.debug(f'Using existing texture {texture_name}')
-                return image
-
         content_manager = ContentManager()
         texture_file = content_manager.find_texture(texture_path / texture_name)
         if texture_file is not None:
@@ -53,7 +47,7 @@ class Source1ShaderBase(ShaderBase):
         dots *= 0.5
         dots += 0.5
 
-        buffer[:, :3] = np.clip(dots, 0, 1)
+        buffer[:, :3] = dots
 
         image.pixels.foreach_set(buffer.ravel())
         image.pack()

--- a/blender_bindings/material_loader/shaders/source1_shader_base.py
+++ b/blender_bindings/material_loader/shaders/source1_shader_base.py
@@ -21,22 +21,12 @@ class Source1ShaderBase(ShaderBase):
         image = check_texture_cache(texture_path / texture_name)
         if image is not None:
             return image
-        
-        # ugly, but we don't want to reuse textures with the same name but different paths
-
-        #for image in bpy.data.images:
-            
-        #print((texture_path / texture_name).as_posix())
 
         for image in bpy.data.images:
             if (fp := image.get('full_path')) == None: continue
             if fp == (texture_path / texture_name).as_posix().lower():
                 self.logger.debug(f'Using existing texture {texture_name}')
                 return image
-
-        #if bpy.data.images.get(texture_name, False):
-        #    self.logger.debug(f'Using existing texture {texture_name}')
-        #    return bpy.data.images.get(texture_name)
 
         content_manager = ContentManager()
         texture_file = content_manager.find_texture(texture_path / texture_name)
@@ -64,7 +54,6 @@ class Source1ShaderBase(ShaderBase):
         dots += 0.5
 
         buffer[:, :3] = np.clip(dots, 0, 1)
-        #buffer[:, 1] = np.subtract(1, buffer[:, 1])
 
         image.pixels.foreach_set(buffer.ravel())
         image.pack()

--- a/blender_bindings/material_loader/shaders/source1_shader_base.py
+++ b/blender_bindings/material_loader/shaders/source1_shader_base.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import bpy
 import numpy as np
+from mathutils import Vector
 
 from ...utils.texture_utils import check_texture_cache
 from ....library.shared.content_providers.content_manager import ContentManager
@@ -9,21 +10,33 @@ from ...source1.vtf import import_texture
 from ..shader_base import ShaderBase
 from ....library.source1.vmt import VMT
 
-
 class Source1ShaderBase(ShaderBase):
     def __init__(self, vmt):
         super().__init__()
         self.load_bvlg_nodes()
         self._vmt: VMT = vmt
         self.textures = {}
-
+    'r'.rsplit()
     def load_texture(self, texture_name: str, texture_path: Path):
         image = check_texture_cache(texture_path / texture_name)
         if image is not None:
             return image
-        if bpy.data.images.get(texture_name, False):
-            self.logger.debug(f'Using existing texture {texture_name}')
-            return bpy.data.images.get(texture_name)
+        
+        # ugly, but we don't want to reuse textures with the same name but different paths
+
+        #for image in bpy.data.images:
+            
+        #print((texture_path / texture_name).as_posix())
+
+        for image in bpy.data.images:
+            if (fp := image.get('full_path')) == None: continue
+            if fp == (texture_path / texture_name).as_posix().lower():
+                self.logger.debug(f'Using existing texture {texture_name}')
+                return image
+
+        #if bpy.data.images.get(texture_name, False):
+        #    self.logger.debug(f'Using existing texture {texture_name}')
+        #    return bpy.data.images.get(texture_name)
 
         content_manager = ContentManager()
         texture_file = content_manager.find_texture(texture_path / texture_name)
@@ -51,7 +64,7 @@ class Source1ShaderBase(ShaderBase):
         dots += 0.5
 
         buffer[:, :3] = np.clip(dots, 0, 1)
-        buffer[:, 1] = np.subtract(1, buffer[:, 1])
+        #buffer[:, 1] = np.subtract(1, buffer[:, 1])
 
         image.pixels.foreach_set(buffer.ravel())
         image.pack()

--- a/blender_bindings/material_loader/shaders/source1_shaders/decalmodulate.py
+++ b/blender_bindings/material_loader/shaders/source1_shaders/decalmodulate.py
@@ -13,7 +13,10 @@ class DecalModulate(Source1ShaderBase):
     def basetexture(self):
         texture_path = self._vmt.get_string('$basetexture', None)
         if texture_path is not None:
-            return self.load_texture_or_default(texture_path, (0.3, 0, 0.3, 1.0))
+            image = self.load_texture_or_default(texture_path, (0.3, 0, 0.3, 1.0))
+            image.is_data = True
+            image.colorspace_settings.name = 'Non-Color'
+
         return None
 
     @property
@@ -36,8 +39,11 @@ class DecalModulate(Source1ShaderBase):
         if super().create_nodes(material) in ['UNKNOWN', 'LOADED']:
             return
 
+        self.bpy_material.blend_method = 'BLEND'
+        self.bpy_material.shadow_method = 'NONE'
+
         material_output = self.create_node(Nodes.ShaderNodeOutputMaterial)
-        shader = self.create_node(Nodes.ShaderNodeBsdfPrincipled, self.SHADER)
+        shader = self.create_node(Nodes.ShaderNodeBsdfTransparent, self.SHADER)
         self.connect_nodes(shader.outputs['BSDF'], material_output.inputs['Surface'])
 
         basetexture = self.basetexture
@@ -46,4 +52,9 @@ class DecalModulate(Source1ShaderBase):
             basetexture_node.image = basetexture
             basetexture_node.id_data.nodes.active = basetexture_node
 
-            self.connect_nodes(basetexture_node.outputs['Color'], shader.inputs['Base Color'])
+            scale = self.create_node(Nodes.ShaderNodeVectorMath)
+            scale.operation = 'SCALE'
+            scale.inputs[3].default_value = 2.0
+
+            self.connect_nodes(basetexture_node.outputs[0], scale.inputs[0])
+            self.connect_nodes(scale.outputs[0], shader.inputs['Color'])

--- a/blender_bindings/material_loader/shaders/source1_shaders/decalmodulate.py
+++ b/blender_bindings/material_loader/shaders/source1_shaders/decalmodulate.py
@@ -14,7 +14,7 @@ class DecalModulate(Source1ShaderBase):
         texture_path = self._vmt.get_string('$basetexture', None)
         if texture_path is not None:
             image = self.load_texture_or_default(texture_path, (0.3, 0, 0.3, 1.0))
-            image.is_data = True
+            image.colorspace_settings.is_data = True
             image.colorspace_settings.name = 'Non-Color'
 
         return None
@@ -41,6 +41,8 @@ class DecalModulate(Source1ShaderBase):
 
         self.bpy_material.blend_method = 'BLEND'
         self.bpy_material.shadow_method = 'NONE'
+
+        self.bpy_material['DECAL'] = True
 
         material_output = self.create_node(Nodes.ShaderNodeOutputMaterial)
         shader = self.create_node(Nodes.ShaderNodeBsdfTransparent, self.SHADER)

--- a/blender_bindings/material_loader/shaders/source1_shaders/decalmodulate.py
+++ b/blender_bindings/material_loader/shaders/source1_shaders/decalmodulate.py
@@ -16,7 +16,7 @@ class DecalModulate(Source1ShaderBase):
             image = self.load_texture_or_default(texture_path, (0.3, 0, 0.3, 1.0))
             image.colorspace_settings.is_data = True
             image.colorspace_settings.name = 'Non-Color'
-
+            return image
         return None
 
     @property
@@ -49,6 +49,7 @@ class DecalModulate(Source1ShaderBase):
         self.connect_nodes(shader.outputs['BSDF'], material_output.inputs['Surface'])
 
         basetexture = self.basetexture
+        print(basetexture)
         if basetexture:
             basetexture_node = self.create_node(Nodes.ShaderNodeTexImage, '$basetexture')
             basetexture_node.image = basetexture

--- a/blender_bindings/material_loader/shaders/source1_shaders/detail.py
+++ b/blender_bindings/material_loader/shaders/source1_shaders/detail.py
@@ -20,16 +20,42 @@ class DetailSupportMixin(Source1ShaderBase):
         return None
 
     @property
+    def detail2(self):
+        texture_path = self._vmt.get_string('$detail2', None)
+        if texture_path is not None:
+            image = self.load_texture_or_default(texture_path, (1.0, 1.0, 1.0, 0.5))
+            image.colorspace_settings.is_data = True
+            image.colorspace_settings.name = 'Non-Color'
+            return image
+        return None
+
+    @property
     def detailfactor(self):
         return self._vmt.get_float('$detailblendfactor', 1)
+    
+    @property
+    def detailfactor2(self):
+        return self._vmt.get_float('$detailblendfactor2', 1)
 
     @property
     def detailmode(self):
-        return self._vmt.get_int('$detailblendmode', -1)
+        return self._vmt.get_int('$detailblendmode', 0)
 
     @property
     def detailscale(self):
         value, value_type = self._vmt.get_vector('$detailscale', [4, 4])
+        if value is None:
+            return None
+        divider = 255 if value_type is int else 1
+        value = list(map(lambda a: a / divider, value))
+        if len(value) == 1:
+            value = [value[0], value[0]]
+        value += (1,)
+        return self.ensure_length(value, 3, 1.0)
+    
+    @property
+    def detailscale2(self):
+        value, value_type = self._vmt.get_vector('$detailscale2', [4, 4])
         if value is None:
             return None
         divider = 255 if value_type is int else 1
@@ -53,6 +79,12 @@ class DetailSupportMixin(Source1ShaderBase):
     @property
     def detailtexturetransform(self):
         return self._vmt.get_transform_matrix('$detailtexturetransform',
+                                              {'center': (0.5, 0.5, 0), 'scale': (1.0, 1.0, 1), 'rotate': (0, 0, 0),
+                                               'translate': (0, 0, 0)})
+    
+    @property
+    def detailtexturetransform2(self):
+        return self._vmt.get_transform_matrix('$basetexturetransform2',
                                               {'center': (0.5, 0.5, 0), 'scale': (1.0, 1.0, 1), 'rotate': (0, 0, 0),
                                                'translate': (0, 0, 0)})
 
@@ -83,6 +115,44 @@ class DetailSupportMixin(Source1ShaderBase):
         scale.inputs[1].default_value = self.detailscale
         if self.detailtexturetransform and uv_node is not None:
             self.handle_transform(self.detailtexturetransform, scale.inputs[0], uv_node=uv_node)
+        else:
+            if uv_node is not None:
+                uv = uv_node
+            else:
+                uv = self.create_node("ShaderNodeUVMap")
+            uv.location = [-1400, -150]
+            self.connect_nodes(uv.outputs[0], scale.inputs[0])
+
+        self.connect_nodes(scale.outputs[0], detail.inputs[0])
+        return detailblend.outputs.get('$basetexture [texture]', albedo_socket), detail
+
+    def handle_detail2(self, next_socket: bpy.types.NodeSocket, albedo_socket: bpy.types.NodeSocket, *, uv_node=None):
+        if self.detailmode not in [0, 1, 2, 5]:
+            logger.error(f'Failed to load detail: unhandled Detail mode, got' + str(self.detailmode))
+            return albedo_socket, None
+        detailblend = self.create_node_group('$DetailBlendMode' + str(self.detailmode), [-500, -60], name='DetailBlend')
+        detailblend.width = 210
+        detailblend.inputs['$detailblendfactor [float]'].default_value = self.detailfactor2
+        if self.detailmode == 5:
+            self.connect_nodes(detailblend.outputs['BSDF'], next_socket.node.outputs['BSDF'].links[0].to_socket)
+            self.connect_nodes(next_socket.node.outputs['BSDF'], detailblend.inputs[0])
+        else:
+            self.connect_nodes(albedo_socket, detailblend.inputs['$basetexture [texture]'])
+            self.connect_nodes(detailblend.outputs['$basetexture [texture]'], next_socket)
+        detail = self.create_and_connect_texture_node(self.detail2,
+                                                      detailblend.inputs['$detail [texture]'],
+                                                      detailblend.inputs.get('$detail alpha [texture alpha]', None),
+                                                      name='$detail')
+        if self.detailmode == 4:
+            self.connect_nodes(albedo_socket.node.outputs['Alpha'],
+                               detailblend.intputs['$basetexture alpha [texture alpha]'])
+        detail.location = [-1100, -130]
+        scale = self.create_node("ShaderNodeVectorMath")
+        scale.location = [-1250, -150]
+        scale.operation = "MULTIPLY"
+        scale.inputs[1].default_value = self.detailscale2
+        if self.detailtexturetransform2 and uv_node is not None:
+            self.handle_transform(self.detailtexturetransform2, scale.inputs[0], uv_node=uv_node)
         else:
             if uv_node is not None:
                 uv = uv_node

--- a/blender_bindings/material_loader/shaders/source1_shaders/lightmap_generic.py
+++ b/blender_bindings/material_loader/shaders/source1_shaders/lightmap_generic.py
@@ -22,7 +22,7 @@ class LightmapGeneric(DetailSupportMixin, Source1ShaderBase):
     def bumpmap(self):
         texture_path = self._vmt.get_string('$bumpmap', None)
         if texture_path is not None:
-            image = self.load_texture_or_default(texture_path, (0.6, 0.0, 0.6, 1.0))
+            image = self.load_texture_or_default(texture_path, (0.217637, 0.217637, 1, 1.0))
             if self.ssbump:
                 image = self.convert_ssbump(image)
             image = self.convert_normalmap(image)

--- a/blender_bindings/material_loader/shaders/source1_shaders/lightmap_generic.py
+++ b/blender_bindings/material_loader/shaders/source1_shaders/lightmap_generic.py
@@ -25,6 +25,7 @@ class LightmapGeneric(DetailSupportMixin, Source1ShaderBase):
             image = self.load_texture_or_default(texture_path, (0.6, 0.0, 0.6, 1.0))
             if self.ssbump:
                 image = self.convert_ssbump(image)
+            image = self.convert_normalmap(image)
             image.colorspace_settings.is_data = True
             image.colorspace_settings.name = 'Non-Color'
             return image

--- a/blender_bindings/material_loader/shaders/source1_shaders/lightmap_generic.py
+++ b/blender_bindings/material_loader/shaders/source1_shaders/lightmap_generic.py
@@ -2,8 +2,9 @@ from ....utils.bpy_utils import is_blender_4
 from ...shader_base import Nodes
 from ..source1_shader_base import Source1ShaderBase
 
+from .detail import DetailSupportMixin
 
-class LightmapGeneric(Source1ShaderBase):
+class LightmapGeneric(DetailSupportMixin, Source1ShaderBase):
     SHADER = 'lightmappedgeneric'
 
     @property
@@ -66,6 +67,11 @@ class LightmapGeneric(Source1ShaderBase):
             basetexture_node = self.create_and_connect_texture_node(basetexture,
                                                                     shader.inputs['Base Color'],
                                                                     name='$basetexture')
+            
+            albedo = basetexture_node.outputs[0]
+
+            if self.detail:
+                albedo, detail = self.handle_detail(shader.inputs['Base Color'], albedo, uv_node=None)
 
             if self.alphatest:
                 self.bpy_material.blend_method = 'HASHED'
@@ -79,7 +85,7 @@ class LightmapGeneric(Source1ShaderBase):
                 self.connect_nodes(basetexture_node.outputs['Alpha'], shader.inputs['Alpha'])
 
         bumpmap = self.bumpmap
-        if bumpmap and not self.ssbump:
+        if bumpmap:
             bumpmap_node = self.create_node(Nodes.ShaderNodeTexImage, '$bumpmap')
             bumpmap_node.image = bumpmap
 

--- a/blender_bindings/material_loader/shaders/source1_shaders/lightmapped_4wayblend.py
+++ b/blender_bindings/material_loader/shaders/source1_shaders/lightmapped_4wayblend.py
@@ -36,10 +36,16 @@ class Lightmapped4WayBlend(Source1ShaderBase):
         return None
 
     @property
+    def ssbump(self):
+        return self._vmt.get_int('$ssbump', 0) == 1
+
+    @property
     def bumpmap(self):
         texture_path = self._vmt.get_string('$bumpmap', None)
         if texture_path is not None:
             image = self.load_texture_or_default(texture_path, (0.6, 0.0, 0.6, 1.0))
+            if self.ssbump:
+                image = self.convert_ssbump(image)
             image.colorspace_settings.is_data = True
             image.colorspace_settings.name = 'Non-Color'
             return image
@@ -51,6 +57,8 @@ class Lightmapped4WayBlend(Source1ShaderBase):
             '$basenormalmap2', None)
         if texture_path is not None:
             image = self.load_texture_or_default(texture_path, (0.6, 0.0, 0.6, 1.0))
+            if self.ssbump:
+                image = self.convert_ssbump(image)
             image.colorspace_settings.is_data = True
             image.colorspace_settings.name = 'Non-Color'
             return image
@@ -61,6 +69,8 @@ class Lightmapped4WayBlend(Source1ShaderBase):
         texture_path = self._vmt.get_string('$basenormalmap3', None)
         if texture_path is not None:
             image = self.load_texture_or_default(texture_path, (0.6, 0.0, 0.6, 1.0))
+            if self.ssbump:
+                image = self.convert_ssbump(image)
             image.colorspace_settings.is_data = True
             image.colorspace_settings.name = 'Non-Color'
             return image
@@ -71,6 +81,8 @@ class Lightmapped4WayBlend(Source1ShaderBase):
         texture_path = self._vmt.get_string('$basenormalmap4', None)
         if texture_path is not None:
             image = self.load_texture_or_default(texture_path, (0.6, 0.0, 0.6, 1.0))
+            if self.ssbump:
+                image = self.convert_ssbump(image)
             image.colorspace_settings.is_data = True
             image.colorspace_settings.name = 'Non-Color'
             return image

--- a/blender_bindings/material_loader/shaders/source1_shaders/lightmapped_4wayblend.py
+++ b/blender_bindings/material_loader/shaders/source1_shaders/lightmapped_4wayblend.py
@@ -46,6 +46,7 @@ class Lightmapped4WayBlend(Source1ShaderBase):
             image = self.load_texture_or_default(texture_path, (0.6, 0.0, 0.6, 1.0))
             if self.ssbump:
                 image = self.convert_ssbump(image)
+            image = self.convert_normalmap(image)
             image.colorspace_settings.is_data = True
             image.colorspace_settings.name = 'Non-Color'
             return image
@@ -59,6 +60,7 @@ class Lightmapped4WayBlend(Source1ShaderBase):
             image = self.load_texture_or_default(texture_path, (0.6, 0.0, 0.6, 1.0))
             if self.ssbump:
                 image = self.convert_ssbump(image)
+            image = self.convert_normalmap(image)
             image.colorspace_settings.is_data = True
             image.colorspace_settings.name = 'Non-Color'
             return image
@@ -71,6 +73,7 @@ class Lightmapped4WayBlend(Source1ShaderBase):
             image = self.load_texture_or_default(texture_path, (0.6, 0.0, 0.6, 1.0))
             if self.ssbump:
                 image = self.convert_ssbump(image)
+            image = self.convert_normalmap(image)
             image.colorspace_settings.is_data = True
             image.colorspace_settings.name = 'Non-Color'
             return image
@@ -83,6 +86,7 @@ class Lightmapped4WayBlend(Source1ShaderBase):
             image = self.load_texture_or_default(texture_path, (0.6, 0.0, 0.6, 1.0))
             if self.ssbump:
                 image = self.convert_ssbump(image)
+            image = self.convert_normalmap(image)
             image.colorspace_settings.is_data = True
             image.colorspace_settings.name = 'Non-Color'
             return image

--- a/blender_bindings/material_loader/shaders/source1_shaders/worldvertextransition.py
+++ b/blender_bindings/material_loader/shaders/source1_shaders/worldvertextransition.py
@@ -2,8 +2,10 @@ from ....utils.bpy_utils import is_blender_4
 from ...shader_base import Nodes
 from ..source1_shader_base import Source1ShaderBase
 
+from .detail import DetailSupportMixin
 
-class WorldVertexTransition(Source1ShaderBase):
+
+class WorldVertexTransition(DetailSupportMixin, Source1ShaderBase):
     SHADER = 'worldvertextransition'
 
     @property
@@ -11,6 +13,17 @@ class WorldVertexTransition(Source1ShaderBase):
         texture_path = self._vmt.get_string('$basetexture', None)
         if texture_path is not None:
             return self.load_texture_or_default(texture_path, (0.3, 0.0, 0.3, 1.0))
+        return None
+    
+    @property
+    def blendmodulatetexture(self):
+        texture_path = self._vmt.get_string('$blendmodulatetexture', None)
+        if texture_path is not None:
+            image = self.load_texture_or_default(texture_path, (0.3, 0.0, 0.3, 1.0))
+            image.colorspace_settings.is_data = True
+            image.colorspace_settings.name = 'Non-Color'
+            return image
+
         return None
 
     @property
@@ -25,6 +38,8 @@ class WorldVertexTransition(Source1ShaderBase):
         texture_path = self._vmt.get_string('$bumpmap', None)
         if texture_path is not None:
             image = self.load_texture_or_default(texture_path, (0.6, 0.0, 0.6, 1.0))
+            if self.ssbump:
+                image = self.convert_ssbump(image)
             image.colorspace_settings.is_data = True
             image.colorspace_settings.name = 'Non-Color'
             return image
@@ -35,8 +50,18 @@ class WorldVertexTransition(Source1ShaderBase):
         texture_path = self._vmt.get_string('$bumpmap2', None)
         if texture_path is not None:
             image = self.load_texture_or_default(texture_path, (0.6, 0.6, 0.0, 1.0))
+            if self.ssbump:
+                image = self.convert_ssbump(image)
             image.colorspace_settings.is_data = True
             image.colorspace_settings.name = 'Non-Color'
+            return image
+        return None
+    
+    @property
+    def detail(self):
+        texture_path = self._vmt.get_string('$detail', None)
+        if texture_path is not None:
+            image = self.load_texture_or_default(texture_path, (0.6, 0.6, 0.0, 1.0))
             return image
         return None
 
@@ -79,8 +104,32 @@ class WorldVertexTransition(Source1ShaderBase):
             vertex_color = self.create_node(Nodes.ShaderNodeVertexColor)
             
             color_mix = self.create_node(Nodes.ShaderNodeMixRGB)
-            self.connect_nodes(vertex_color.outputs['Color'], color_mix.inputs['Fac'])
+            if self.blendmodulatetexture != None:
+                SEPrgb = self.create_node(Nodes.ShaderNodeSeparateRGB)
+                sub = self.create_node(Nodes.ShaderNodeMath)
+                sub.operation = 'SUBTRACT'
+                add = self.create_node(Nodes.ShaderNodeMath)
+                add.operation = 'ADD'
+                maprange = self.create_node(Nodes.ShaderNodeMapRange)
+                maprange.interpolation_type = 'SMOOTHSTEP'
+
+                self.connect_nodes(SEPrgb.outputs[1], sub.inputs[0])
+                self.connect_nodes(SEPrgb.outputs[0], sub.inputs[1])
+                self.connect_nodes(SEPrgb.outputs[0], add.inputs[0])
+                self.connect_nodes(SEPrgb.outputs[1], add.inputs[1])
+                self.connect_nodes(sub.outputs[0], maprange.inputs[1])
+                self.connect_nodes(add.outputs[0], maprange.inputs[2])
+                self.connect_nodes(vertex_color.outputs[0], maprange.inputs[0])
+                self.connect_nodes(maprange.outputs[0], color_mix.inputs['Fac'])
+
+                self.create_and_connect_texture_node(self.blendmodulatetexture, SEPrgb.inputs[0], name='$blendmodulatedecal')
+
+                #self.create_texture_node(self.blendmodulatetexture, '$blendmodulatedecal')
+            else:
+                self.connect_nodes(vertex_color.outputs['Color'], color_mix.inputs['Fac'])
             color_mix.blend_type = 'MIX'
+
+            albedo = color_mix.outputs[0]
 
             self.create_and_connect_texture_node(basetexture,
                                                  color_mix.inputs['Color1'],
@@ -88,8 +137,11 @@ class WorldVertexTransition(Source1ShaderBase):
             self.create_and_connect_texture_node(basetexture2,
                                                  color_mix.inputs['Color2'],
                                                  name='$basetexture2')
-
-            self.connect_nodes(color_mix.outputs['Color'], shader.inputs['Base Color'])
+            
+            if self.detail:
+                albedo, detail = self.handle_detail(shader.inputs['Base Color'], albedo, uv_node=None)
+            else:
+                self.connect_nodes(color_mix.outputs['Color'], shader.inputs['Base Color'])
 
         if not self.phong:
             if is_blender_4():

--- a/blender_bindings/utils/bpy_utils.py
+++ b/blender_bindings/utils/bpy_utils.py
@@ -34,9 +34,12 @@ def add_material(material, model_ob):
 
 def get_or_create_material(name: str, full_path: str):
     for mat in bpy.data.materials:
-        if name in mat.name and mat.get("full_path") == full_path:
+        if (fp := mat.get('full_path')) == None:
+            continue
+        if fp.lower() == full_path.lower():
             return mat
-    mat = bpy.data.materials.new(name)
+    mat = bpy.data.materials.new(name[-63:])
+    mat.name = name[-63:]
     mat["full_path"] = full_path
     mat.diffuse_color = [random.uniform(.4, 1) for _ in range(3)] + [1.0]
     return mat

--- a/blender_bindings/utils/resource_utils.py
+++ b/blender_bindings/utils/resource_utils.py
@@ -7,6 +7,8 @@ def serialize_mounted_content(cm: ContentManager):
     data = cm.serialize()
     resources = bpy.context.scene.mounted_resources
     for item_hash, item in data.items():
+        if (resource := resources.get(item['name'])) != None:
+            if resource.path == item['path']: continue
         new_resource = resources.add()
         new_resource.path = item["path"]
         new_resource.name = item["name"]

--- a/blender_bindings/utils/texture_utils.py
+++ b/blender_bindings/utils/texture_utils.py
@@ -34,6 +34,11 @@ def _add_texture(texture_path: Path, real_name: str, *other_args):
 
 
 def check_texture_cache(texture_path: Path) -> Optional[bpy.types.Image]:
+    for image_existing in bpy.data.images:
+        if (fp := image_existing.get('full_path')) == None: continue
+        if fp == texture_path.as_posix().lower():
+            return image_existing
+
     short_name = _get_texture(texture_path)
     if short_name is not None:
         if short_name + '.png' in bpy.data.images:
@@ -70,8 +75,8 @@ def create_and_cache_texture(texture_path: Path, dimensions: tuple[int, int], da
     if invert_y and not is_hdr:
         data[:, :, 1] = 1 - data[:, :, 1]
 
-    image['full_path'] = Path(texture_path).as_posix()
     image.pixels.foreach_set(data.ravel())
+    image['full_path'] = Path(texture_path).as_posix().lower()
     if bpy.context.scene.TextureCachePath != "":
         save_path = Path(bpy.context.scene.TextureCachePath) / texture_path
         save_path = save_path.with_suffix(".hdr" if is_hdr else ".png")

--- a/blender_bindings/utils/texture_utils.py
+++ b/blender_bindings/utils/texture_utils.py
@@ -70,6 +70,7 @@ def create_and_cache_texture(texture_path: Path, dimensions: tuple[int, int], da
     if invert_y and not is_hdr:
         data[:, :, 1] = 1 - data[:, :, 1]
 
+    image['full_path'] = Path(texture_path).as_posix()
     image.pixels.foreach_set(data.ravel())
     if bpy.context.scene.TextureCachePath != "":
         save_path = Path(bpy.context.scene.TextureCachePath) / texture_path


### PR DESCRIPTION
# General
## Self-shadowing bump maps  
Code to convert ss-bump maps to normal maps has been implemented, courtesy of [rob5300](https://github.com/rob5300/ssbumpToNormal-Win/blob/main/SSBumpToNormal.cs)

# WorldVertexTransition
## Two-layer detail
Support for one or more detail layers have been added

## Loading SS bump maps
Now calls to load and convert ss bump maps if any

## BlendModulateTexture
Now loads $blendmodulatetexture's to add detail to blending between two textures, using a texture instead of a linear blend

New  
<img src="https://github.com/REDxEYE/SourceIO/assets/41131633/29540083-4ddb-4f9b-9d85-b4df177cd89a" height=200>  

Old  
<img src="https://github.com/REDxEYE/SourceIO/assets/41131633/1e6b3bcf-1076-47ba-957d-f8c216c96fd7" height=200>

# DecalModulate
## Proper implentation
Instead of using a pBSDF and plugging in the texture, the texture is now set to `Non-Color`, scaled by two and plugged into a Transparent BSDF for a proper implementation.

New  
<img src="https://github.com/REDxEYE/SourceIO/assets/41131633/09f87c42-0da4-4771-930f-33ea58559b86" height=200>

Old  
<img src="https://github.com/REDxEYE/SourceIO/assets/41131633/3acfd951-84a7-40e9-b372-f2857e4cbdb7" height=200>
<img src="https://github.com/REDxEYE/SourceIO/assets/41131633/2387977b-7dbf-4933-b186-0608ad54fb8a" width=200>

# LightMappedGeneric
## Support for detail
Support for one or more detail layers have been added

## Loading SS bump maps
Now calls to load and convert ss bump maps if any

New  
<img src="https://github.com/REDxEYE/SourceIO/assets/41131633/f70abb69-3a16-4711-9881-72c6f509e1a1" height=200>

Old  
<img src="https://github.com/REDxEYE/SourceIO/assets/41131633/6b52da29-2b4f-4c55-b75a-97e0f42acce3" height=200>


# detail.py
## Support for two layer detail
A new function was created to handle the second detail layer, if any. Called by `self.handle_detail2`

New (dz_sirocco)
<img src="https://github.com/REDxEYE/SourceIO/assets/41131633/fc39e8a2-b282-4679-8aee-a6b9a39e9c66" height=400>

Old
<img src="https://github.com/REDxEYE/SourceIO/assets/41131633/d671d28a-c313-44b6-b644-7b928849e3ed" height=400>

# utils/texture_utils.py
## Proper reusing of textures
Texture paths as posix are now saved as a custom property. When calling `check_texture_cache`, it will go through all images and check if an image has the same path. If true, then reuse.

# BlenderVertexLitGeneric
## $DetailBlendMode0
Proper implementation. Detail textures are scaled by two and then multiplied onto albedo

## Removed default envmap
The default envmap messed with creating asset previews for objects. Instead, an input for an envmap mask has been created on VertexLitGeneric, and a new node group was added to map out the environment map.

New
<img src="https://github.com/REDxEYE/SourceIO/assets/41131633/bab9ce56-7c77-4351-8dac-f6fae09ac840" height=250>
<img src="https://github.com/REDxEYE/SourceIO/assets/41131633/6b615957-0eb2-4655-ac2b-49b078c721e6" height=150>

Old  
<img src="https://github.com/REDxEYE/SourceIO/assets/41131633/e3ab45b2-1e8d-4730-b277-8c54b20a51d6" height=250>
<img src="https://github.com/REDxEYE/SourceIO/assets/41131633/92281ecc-d673-4094-83f3-60e41ff6d95f" height=150>

# Suggestions
Store skin groups as material `bpy.data.materials` instead of strings. This works with a dictionary as a custom property and is better to use when exchanging skins.