### PR TITLE
VtMB: fix compressed prop sizes and materials for imported maps

### DIFF
--- a/blender_bindings/source1/mdl/v2531/import_mdl.py
+++ b/blender_bindings/source1/mdl/v2531/import_mdl.py
@@ -134,13 +134,14 @@ def import_model(file_list: FileImport,
 
             if model.vtype == 1:
                 normals = vertices['normal']
-                vertex_data = vertex_data.astype(np.float32) * np.asarray(model.vscale, np.float32) + np.asarray(
+                # TODO: Verify the division by uint16 max by finding a model that uses it in a map
+                vertex_data = (vertex_data.astype(np.float32) / 65535.0) * np.asarray(model.vscale, np.float32) + np.asarray(
                     model.voffset, np.float32)
                 normals = normals.astype(np.float32) / 255
                 uvs = np.hstack([vertices["u"], vertices["v"]])
                 uvs = uvs.astype(np.float32) / 255
             elif model.vtype == 2:
-                vertex_data = vertex_data.astype(np.float32) * np.asarray(model.vscale, np.float32) + np.asarray(
+                vertex_data = (vertex_data.astype(np.float32) / 255.0) * np.asarray(model.vscale, np.float32) + np.asarray(
                     model.voffset, np.float32)
                 normals = np.hstack([vertices["normal.xy"], vertices["normal.z"]])
                 normals = normals.astype(np.float32) / 255

--- a/library/source1/vmt/__init__.py
+++ b/library/source1/vmt/__init__.py
@@ -30,11 +30,12 @@ class VMT:
     def _postprocess(self):
         content_manager = ContentManager()
         if self.shader == 'patch':
-            original_material = content_manager.find_file(self.get_string('include'))
+            look_for = self.get_string('include')
+            original_material = content_manager.find_material(look_for)
             if not original_material:
-                logger.error(f'Failed to find original material {self.get_string("include")!r}')
+                logger.error(f'Failed to find original material: {look_for!r}')
                 return
-            patched_vmt = VMT(original_material, self.get_string('include'))
+            patched_vmt = VMT(original_material, look_for)
             if 'insert' in self:
                 patch_data = self.get('insert', {})
                 patched_vmt.data.merge(patch_data)


### PR DESCRIPTION
This fixes some import issues seen in the VtMB support, namely the sizes of static_props that were compressed (previously they were huge) and it also fixes the search for material VMT files as they don't always seem to include a full path with a correct suffix.

I was thinking about trying to rebase this branch onto master as well, are there any stoppers for that?