### PR TITLE
Source one shaders fixes and additions, new skin group saving method

### DIFF
--- a/blender_bindings/material_loader/material_loader.py
+++ b/blender_bindings/material_loader/material_loader.py
@@ -46,7 +46,16 @@ class Source1MaterialLoader(MaterialLoaderBase):
                                                                                             self.vmt)
 
         handler.create_nodes(material)
-
+        material['shader_type'] = handler._vmt.shader
+        try:
+            params = handler._vmt.data.to_dict()
+            #if (dx90 := (params.get('>=dx90') or params.get('>=DX90'))):
+            #    for key, value in dx90.items():
+            #        params[key] = value
+            #    # unravel it a bit, because dx90 is how we usually see the materials
+            material['vmt_parameters'] = handler._vmt.data.to_dict()
+        except:
+            pass
         handler.align_nodes()
         if self.vmt.shader not in self._handlers:
             logger.error(f'Shader "{self.vmt.shader}" not currently supported by SourceIO')

--- a/blender_bindings/material_loader/node_arranger.py
+++ b/blender_bindings/material_loader/node_arranger.py
@@ -9,7 +9,7 @@ class values():
     x_last = 0
     margin_x = 300
     mat_name = ""
-    margin_y = 20
+    margin_y = 300
 
 
 def outputnode_search(ntree):  # return node/None

--- a/blender_bindings/material_loader/shader_base.py
+++ b/blender_bindings/material_loader/shader_base.py
@@ -224,7 +224,7 @@ class ShaderBase:
     def create_node_group(self, group_name, location=None, *, name=None):
         group_node = self.create_node(Nodes.ShaderNodeGroup, name or group_name)
         group_node.node_tree = bpy.data.node_groups.get(group_name)
-        group_node.width = group_node.bl_width_max
+        group_node.width = 240
         if location is not None:
             group_node.location = location
         return group_node

--- a/blender_bindings/material_loader/shader_base.py
+++ b/blender_bindings/material_loader/shader_base.py
@@ -10,7 +10,6 @@ from ...logger import SourceLogMan
 from ..utils.bpy_utils import append_blend
 from .node_arranger import nodes_iterate
 
-
 class Nodes:
     ShaderNodeAddShader = 'ShaderNodeAddShader'
     ShaderNodeAmbientOcclusion = 'ShaderNodeAmbientOcclusion'

--- a/blender_bindings/material_loader/shaders/source1_shader_base.py
+++ b/blender_bindings/material_loader/shaders/source1_shader_base.py
@@ -14,6 +14,10 @@ class Source1ShaderBase(ShaderBase):
         super().__init__()
         self.content_manager = content_manager
         self.load_bvlg_nodes()
+        if (dx90 := (vmt.get('>=dx90') or vmt.get('>=DX90'))):
+            # unravel it, because we want dx90 properties
+            for key, value in dx90.items():
+                vmt[key] = value
         self._vmt: VMT = vmt
         self.textures = {}
 

--- a/blender_bindings/material_loader/shaders/source1_shaders/__init__.py
+++ b/blender_bindings/material_loader/shaders/source1_shaders/__init__.py
@@ -1,4 +1,4 @@
 from . import (cable, decalmodulate, eyerefract, heroes_armor, heroes_faceskin,
                lightmap_generic, lightmapped_4wayblend, refract, unlit_generic,
                unlittwotexture, vertexlit_generic, water,
-               worldvertextransition)
+               worldvertextransition, modulate)

--- a/blender_bindings/material_loader/shaders/source1_shaders/infected.py
+++ b/blender_bindings/material_loader/shaders/source1_shaders/infected.py
@@ -1,0 +1,422 @@
+from ....utils.bpy_utils import is_blender_4
+from ...shader_base import Nodes
+from ..source1_shader_base import Source1ShaderBase
+from .detail import DetailSupportMixin
+
+
+class Infected(DetailSupportMixin, Source1ShaderBase):
+    SHADER: str = 'infected'
+
+    @property
+    def bumpmap(self):
+        texture_path = self._vmt.get_string('$bumpmap', None)
+        if texture_path is not None:
+            image = self.load_texture_or_default(texture_path, (0.5, 0.5, 1.0, 1.0))
+            image = self.convert_normalmap(image)
+            image.colorspace_settings.is_data = True
+            image.colorspace_settings.name = 'Non-Color'
+            return image
+        return None
+
+    @property
+    def basetexture(self):
+        texture_path = self._vmt.get_string('$basetexture', None)
+        if texture_path is not None:
+            image = self.load_texture_or_default(texture_path, (0.3, 0, 0.3, 1.0))
+            image.colorspace_settings.is_data = True
+            image.colorspace_settings.name = 'Non-Color'
+            return image
+        return None
+    
+    @property
+    def gradienttexture(self):
+        texture_path = self._vmt.get_string('$gradienttexture', None)
+        if texture_path is not None:
+            image = self.load_texture_or_default(texture_path, (0.3, 0, 0.3, 1.0))
+            return image
+        return None
+    
+    @property
+    def detail(self):
+        texture_path = self._vmt.get_string('$detail', None)
+        if texture_path is not None:
+            image = self.load_texture_or_default(texture_path, (0.3, 0, 0.3, 1.0))
+            return image
+        return None
+    
+    @property
+    def detailscale(self):
+        value = self._vmt.get_float('$detailscale', 1.0)
+        return value
+
+    @property
+    def basetexturetransform(self):
+        return self._vmt.get_transform_matrix('$basetexturetransform',
+                                              {'center': (0.5, 0.5, 0), 'scale': (1.0, 1.0, 1), 'rotate': (0, 0, 0),
+                                               'translate': (0, 0, 0)})
+
+    @property
+    def phongexponenttexture(self):
+        texture_path = self._vmt.get_string('$phongexponenttexture', None)
+        if texture_path is not None:
+            image = self.load_texture_or_default(texture_path, (0.5, 0.0, 0.0, 1.0))
+            image.colorspace_settings.is_data = True
+            image.colorspace_settings.name = 'Non-Color'
+            return image
+        return None
+    
+    @property
+    def phong(self):
+        return self._vmt.get_int('$phong', 0) == 1
+    
+    @property
+    def phongfresnelranges(self):
+        value, value_type = self._vmt.get_vector('$phongfresnelranges', None)
+        if value is not None:
+            divider = 255 if value_type is int else 1
+            value = list(map(lambda a: a / divider, value))
+            return self.ensure_length(value, 3, 0.1)
+        return None
+
+    @property
+    def phongexponent(self):
+        value = self._vmt.get_float('$defaultphongexponent', None)
+        return value
+
+    @property
+    def phongboost(self):
+        value = self._vmt.get_float('$phongboost', 1)
+        return value
+
+    @property
+    def phongtint(self):
+        color_value, value_type = self._vmt.get_vector('$phongtint', None)
+        if color_value is None:
+            return None
+        divider = 255 if value_type is int else 1
+        color_value = list(map(lambda a: (a / divider) ** 2.2 if value_type is int else 1, color_value))
+        if len(color_value) == 1:
+            color_value = [color_value[0], color_value[0], color_value[0]]
+        return self.ensure_length(color_value, 4, 1.0)
+    ### BLOOD ###
+
+    @property
+    def bloodcolor(self):
+        color_value, value_type = self._vmt.get_vector('$bloodcolor', None)
+        if color_value is None:
+            return None
+        divider = 255 if value_type is int else 1
+        color_value = list(map(lambda a: a / divider, color_value))
+        #color_value = list(map(lambda a: (a / divider) ** (2.2 if value_type is int else 1), color_value))
+        #print(f'\n\n{color_value}\n\n')
+        if len(color_value) == 1:
+            color_value = [color_value[0], color_value[0], color_value[0]]
+        return self.ensure_length(color_value, 4, 1.0)
+    
+    @property
+    def bloodspecboost(self):
+        value = self._vmt.get_float('$bloodspecboost', 1.0)
+        return value
+
+    @property
+    def bloodphongexponent(self):
+        value = self._vmt.get_int('$bloodphongexponent', 200)
+        return value
+    
+    @property
+    def bloodmaskrange(self):
+        value, value_type = self._vmt.get_vector('$bloodmaskrange', None)
+        if value is not None:
+            divider = 255 if value_type is int else 1
+            value = list(map(lambda a: a / divider, value))
+            return self.ensure_length(value, 3, 0.0)
+        return None
+    
+    ###############
+
+    ### EYEGLOW ###
+
+    @property
+    def eyeglow(self):
+        value = self._vmt.get_int('$eyeglow', 0.0)
+        return value
+    
+    @property
+    def eyeglowcolor(self):
+        color_value, value_type = self._vmt.get_vector('$eyeglowcolor', None)
+        if color_value is None:
+            return None
+        divider = 255 if value_type is int else 1
+        color_value = list(map(lambda a: (a / divider) ** (2.2 if value_type is int else 1), color_value))
+        print(f'EYEGLOW {color_value}')
+        #if len(color_value) == 1:
+        #    color_value = [color_value[0], color_value[0], color_value[0]]
+        return self.ensure_length(color_value, 4, 1.0)
+
+    @property
+    def eyeglowflashlightboost(self):
+        value = self._vmt.get_float('$eyeglowflashlightboost', 1.0)
+        return value
+    
+    ###############
+
+    @property
+    def sheetindex(self):
+        value = self._vmt.get_int('$sheetindex', -1)
+        return value
+    
+    @property
+    def skintintgradient(self):
+        value = self._vmt.get_int('$skintintgradient', -1)
+        return value
+    
+    @property
+    def colortintgradient(self):
+        value = self._vmt.get_int('$colortintgradient', -1)
+        return value
+    
+    @property
+    def skinphongexponent(self):
+        value = self._vmt.get_int('$skinphongexponent', 16)
+        return value
+
+    @property
+    def eyeglowflashlightboost(self):
+        value = self._vmt.get_float('$eyeglowflashlightboost', 1.0)
+        return value
+
+    @property
+    def disablevariation(self):
+        value = self._vmt.get_int('$disablevariation', 0)
+        return value
+
+    def create_nodes(self, material):
+        self.do_arrange = False
+        print(f"BVLG: {self.use_bvlg_status}")
+        if super().create_nodes(material) in ['UNKNOWN', 'LOADED']:
+            return
+
+        material_output = self.create_node(Nodes.ShaderNodeOutputMaterial)
+        material_output.location = [400, -140]
+        parentnode = material_output
+
+        uv = None
+        if self.use_bvlg_status:
+            self.do_arrange = False
+
+            group_node = self.create_node_group("infected", [-60, -140])
+            self.connect_nodes(group_node.outputs['BSDF'], parentnode.inputs[0])
+            if self.basetexture:
+                if not self.disablevariation:
+                    basetexture_sprite_node = self.create_and_connect_texture_node(self.basetexture,
+                                                                            group_node.inputs['$basetexture sprite [texture]'],
+                                                                            name='$basetexture sprite')
+                    
+                    base_img = basetexture_sprite_node.image
+
+                    basetexture_sprite_node.location = [-400, 20]
+
+                    #sprite_sheet_uv = self.create_node_group('SpriteSheet', [-660, 20])
+                    #sprite_sheet_uv.width=140
+                    #self.connect_nodes(sprite_sheet_uv.outputs[0], basetexture_sprite_node.inputs[0])
+
+                    randomIndex = self.create_node_group('random2x2Tile', [-840, 20])
+                    randomIndex.width = 140
+                    self.connect_nodes(randomIndex.outputs[0], basetexture_sprite_node.inputs[0])
+
+                    basetexture = self.create_texture_node(self.basetexture, name='$basetexture', location=[-800, -220])
+                    gradient = self.create_texture_node(self.gradienttexture, name='$gradienttexture', location=[-340, -300])
+                    gradient.extension = 'CLIP'
+                    gradient.interpolation = 'Closest'
+                    gradientSampler = self.create_node_group('sampleColorPalette', [-540, -420])
+                    gradientSampler.width = 140
+
+                    self.connect_nodes(basetexture_sprite_node.outputs[0], group_node.inputs['$basetexture sprite [texture]'])
+                    self.connect_nodes(basetexture.outputs[0], group_node.inputs['$basetexture [texture]'])
+                    self.connect_nodes(basetexture.outputs[0], gradientSampler.inputs[0])
+                    self.connect_nodes(basetexture.outputs[1], group_node.inputs['$basetexture alpha [float]'])
+                    self.connect_nodes(basetexture.outputs[1], gradientSampler.inputs[1])
+                    self.connect_nodes(gradientSampler.outputs[0], gradient.inputs[0])
+                    self.connect_nodes(gradient.outputs[0], group_node.inputs['$gradienttexture'])
+
+                    if self.sheetindex:
+                        randomIndex.inputs[2].default_value = self.sheetindex
+
+                    if self.skintintgradient:
+                        gradientSampler.inputs[2].default_value = self.skintintgradient
+
+                    if self.colortintgradient:
+                        gradientSampler.inputs[3].default_value = self.colortintgradient
+
+                    if self.detail:
+                        detail = self.create_and_connect_texture_node(self.detail,
+                            group_node.inputs['$detail [texture]'],
+                            name='$detail')
+                        detail.location = [-380, -600]
+                        
+                        if self.detailscale:
+                            uv = self.create_node(Nodes.ShaderNodeUVMap, name='UV Map', location=[-760, -700])
+                            scaler = self.create_node(Nodes.ShaderNodeVectorMath, name='$detailscale', location=[-580, -700])
+                            scaler.inputs[3].default_value = self.detailscale
+                            scaler.operation = 'SCALE'
+
+                            self.connect_nodes(uv.outputs[0], scaler.inputs[0])
+                            self.connect_nodes(scaler.outputs[0], detail.inputs[0])
+
+                else:
+                    basetexture_node = self.create_and_connect_texture_node(self.basetexture,
+                                                                            group_node.inputs['$basetexture [texture]'],
+                                                                            name='$basetexture')
+
+                    basetexture_node.image.colorspace_settings.name = 'sRGB'
+                    basetexture_node.image.colorspace_settings.is_data = False
+                    basetexture_node.location = [-380, -140]
+
+                    group_node.inputs['$disablevariation'].default_value = True
+
+            if self.bumpmap:
+                bumpmap_node = self.create_and_connect_texture_node(self.bumpmap,
+                                                                    group_node.inputs['$bumpmap [texture]'],
+                                                                    name='$bumpmap')
+                bumpmap_node.location = [-800, -220]
+                if self.normalmapalphaenvmapmask:
+                    self.connect_nodes(bumpmap_node.outputs['Alpha'],
+                                       group_node.inputs['envmapmask [basemap texture alpha]'])
+            
+            if self.bloodcolor:
+                group_node.inputs['$bloodcolor [vector]'].default_value = self.bloodcolor
+                print(f'\n\nBLOODCOLOR {self.bloodcolor}\n\n')
+
+            if self.bloodmaskrange:
+                group_node.inputs['$bloodmaskrange [vector2]'].default_value = self.bloodmaskrange
+
+            if self.bloodspecboost:
+                group_node.inputs['$bloodspecboost'].default_value = self.bloodspecboost
+            
+            if self.bloodphongexponent:
+                group_node.inputs['$bloodphongexponent'].default_value = self.bloodphongexponent
+
+            if self.eyeglow:
+                group_node.inputs['$eyeglow [bool]'].default_value = self.eyeglow
+
+            if self.eyeglowcolor:
+                group_node.inputs['$eyeglowcolor [color]'].default_value = self.eyeglowcolor
+
+            if self.eyeglowflashlightboost:
+                group_node.inputs['$eyeglowflashlightboost [float]'].default_value = self.eyeglowflashlightboost
+
+            if self.skinphongexponent:
+                group_node.inputs['$skinphongexponent [int]'].default_value = self.skinphongexponent
+
+            if self.phong:
+                group_node.inputs['$phong [bool]'].default_value = 1
+                if self.phongboost:
+                    group_node.inputs['$phongboost [value]'].default_value = self.phongboost
+                if self.phongexponent:
+                    group_node.inputs['$defaultphongexponent [value]'].default_value = self.phongexponent
+
+                else:
+                    group_node.inputs['$defaultphongexponent [value]'].default_value = 10
+
+                if self.phongtint is not None:
+                    group_node.inputs['$phongtint [RGB field]'].default_value = self.phongtint
+
+                if self.phongfresnelranges:
+                    group_node.inputs['$phongfresnelranges [value field]'].default_value = self.phongfresnelranges
+
+        else:
+            shader = self.create_node(Nodes.ShaderNodeBsdfPrincipled, self.SHADER)
+            self.connect_nodes(shader.outputs['BSDF'], material_output.inputs['Surface'])
+
+            basetexture = self.basetexture
+            if basetexture:
+                basetexture_node = self.create_node(Nodes.ShaderNodeTexImage, '$basetexture')
+                basetexture_node.image = basetexture
+                basetexture_node.id_data.nodes.active = basetexture_node
+
+                if self.color or self.color2:
+                    color_mix = self.create_node(Nodes.ShaderNodeMixRGB)
+                    color_mix.blend_type = 'MULTIPLY'
+                    self.connect_nodes(basetexture_node.outputs['Color'], color_mix.inputs['Color1'])
+                    color_mix.inputs['Color2'].default_value = (self.color or self.color2)
+                    color_mix.inputs['Fac'].default_value = 1.0
+                    self.connect_nodes(color_mix.outputs['Color'], shader.inputs['Base Color'])
+                else:
+                    self.connect_nodes(basetexture_node.outputs['Color'], shader.inputs['Base Color'])
+                if self.translucent or self.alphatest:
+                    self.connect_nodes(basetexture_node.outputs['Alpha'], shader.inputs['Alpha'])
+
+                if self.additive:
+                    basetexture_invert_node = self.create_node(Nodes.ShaderNodeInvert)
+                    basetexture_additive_mix_node = self.create_node(Nodes.ShaderNodeMixRGB)
+                    self.insert_node(basetexture_node.outputs['Color'], basetexture_additive_mix_node.inputs['Color1'],
+                                     basetexture_additive_mix_node.outputs['Color'])
+                    basetexture_additive_mix_node.inputs['Color2'].default_value = (1.0, 1.0, 1.0, 1.0)
+
+                    self.connect_nodes(basetexture_node.outputs['Color'], basetexture_invert_node.inputs['Color'])
+                    if is_blender_4():
+                        self.connect_nodes(basetexture_invert_node.outputs['Color'],
+                                           shader.inputs['Transmission Weight'])
+                    else:
+                        self.connect_nodes(basetexture_invert_node.outputs['Color'], shader.inputs['Transmission'])
+                    self.connect_nodes(basetexture_invert_node.outputs['Color'],
+                                       basetexture_additive_mix_node.inputs['Fac'])
+
+            bumpmap = self.bumpmap
+            if bumpmap:
+                bumpmap_node = self.create_node(Nodes.ShaderNodeTexImage, '$bumpmap')
+                bumpmap_node.image = bumpmap
+
+                normalmap_node = self.create_node(Nodes.ShaderNodeNormalMap)
+
+                self.connect_nodes(bumpmap_node.outputs['Color'], normalmap_node.inputs['Color'])
+                self.connect_nodes(normalmap_node.outputs['Normal'], shader.inputs['Normal'])
+
+            if self.selfillum and basetexture:
+                basetexture_node = self.get_node('$basetexture')
+                if basetexture_node:
+                    selfillummask = self.selfillummask
+                    if selfillummask is not None:
+                        selfillummask_node = self.create_node(Nodes.ShaderNodeTexImage, '$selfillummask')
+                        selfillummask_node.image = selfillummask
+                        if 'Emission Strength' in shader.inputs:
+                            self.connect_nodes(selfillummask_node.outputs['Color'], shader.inputs['Emission Strength'])
+                    else:
+                        if 'Emission Strength' in shader.inputs:
+                            self.connect_nodes(basetexture_node.outputs['Alpha'], shader.inputs['Emission Strength'])
+                    if is_blender_4():
+                        self.connect_nodes(basetexture_node.outputs['Color'], shader.inputs['Emission Color'])
+                    else:
+                        self.connect_nodes(basetexture_node.outputs['Color'], shader.inputs['Emission'])
+
+            if not self.phong:
+                if is_blender_4():
+                    shader.inputs['Specular IOR Level'].default_value = 0
+                else:
+                    shader.inputs['Specular'].default_value = 0
+            elif self.phongboost is not None:
+                if is_blender_4():
+                    shader.inputs['Specular IOR Level'].default_value = self.clamp_value(self.phongboost / 64)
+                else:
+                    shader.inputs['Specular'].default_value = self.clamp_value(self.phongboost / 64)
+            phongexponenttexture = self.phongexponenttexture
+            if self.phongexponent is not None and phongexponenttexture is None:
+                shader.inputs['Roughness'].default_value = self.clamp_value(self.phongexponent / 256)
+            elif self.phongexponenttexture is not None:
+                phongexponenttexture_node = self.create_node(Nodes.ShaderNodeTexImage, '$phongexponenttexture')
+                phongexponenttexture_node.image = phongexponenttexture
+                phongexponenttexture_split_node = self.create_node(Nodes.ShaderNodeSeparateRGB)
+                self.connect_nodes(phongexponenttexture_node.outputs['Color'],
+                                   phongexponenttexture_split_node.inputs['Image'])
+
+                phongexponenttexture_r_invert_node = self.create_node(Nodes.ShaderNodeInvert)
+                self.connect_nodes(phongexponenttexture_split_node.outputs['R'],
+                                   phongexponenttexture_r_invert_node.inputs['Color'])
+                self.connect_nodes(phongexponenttexture_split_node.outputs['G'],
+                                   shader.inputs['Metallic'])
+
+                self.connect_nodes(phongexponenttexture_r_invert_node.outputs['Color'], shader.inputs['Roughness'])
+
+
+class SDKInfected(Infected):
+    SHADER: str = 'sdk_infected'

--- a/blender_bindings/material_loader/shaders/source1_shaders/lightmap_generic.py
+++ b/blender_bindings/material_loader/shaders/source1_shaders/lightmap_generic.py
@@ -46,6 +46,12 @@ class LightmapGeneric(DetailSupportMixin, Source1ShaderBase):
     @property
     def alphatest(self):
         return self._vmt.get_int('$alphatest', 0) == 1
+    
+    @property
+    def basetexturetransform(self):
+        return self._vmt.get_transform_matrix('$basetexturetransform',
+                                                        {'center': (0.5, 0.5, 0), 'scale': (1.0, 1.0, 1), 'rotate': (0, 0, 0),
+                                                        'translate': (0, 0, 0)})
 
     @property
     def translucent(self):
@@ -70,6 +76,9 @@ class LightmapGeneric(DetailSupportMixin, Source1ShaderBase):
                                                                     name='$basetexture')
             
             albedo = basetexture_node.outputs[0]
+            if self.basetexturetransform:
+                uv, self.uv_map = self.handle_transform(self.basetexturetransform, basetexture_node.inputs[0])
+                
 
             if self.detail:
                 albedo, detail = self.handle_detail(shader.inputs['Base Color'], albedo, uv_node=None)

--- a/blender_bindings/material_loader/shaders/source1_shaders/modulate.py
+++ b/blender_bindings/material_loader/shaders/source1_shaders/modulate.py
@@ -78,4 +78,17 @@ class Modulate(Source1ShaderBase):
         transparent = self.create_node(Nodes.ShaderNodeBsdfTransparent)
         self.connect_nodes(mult.outputs[0], transparent.inputs[0])
         out = self.create_node(Nodes.ShaderNodeOutputMaterial)
-        self.connect_nodes(transparent.outputs[0], out.inputs[0])
+
+        culling = self.create_node_group('BackfaceCulling')
+        self.connect_nodes(transparent.outputs[0], culling.inputs[0])
+
+        # so we can toggle backface culling across eevee and cycles with one boolean property
+        driv = culling.inputs['$nocull'].driver_add('default_value')
+        driv.driver.expression = '1-var'
+        var = driv.driver.variables.new()
+        var.type = 'SINGLE_PROP'
+        var.targets[0].id_type = 'MATERIAL'
+        var.targets[0].id = self.bpy_material
+        var.targets[0].data_path = 'use_backface_culling'
+
+        self.connect_nodes(culling.outputs[0], out.inputs[0])

--- a/blender_bindings/material_loader/shaders/source1_shaders/modulate.py
+++ b/blender_bindings/material_loader/shaders/source1_shaders/modulate.py
@@ -1,0 +1,79 @@
+from SourceIO.blender_bindings.utils.bpy_utils import is_blender_4
+from ...shader_base import Nodes
+from ..source1_shader_base import Source1ShaderBase
+
+
+class Modulate(Source1ShaderBase):
+    SHADER: str = 'modulate'
+
+    @property
+    def basetexture(self):
+        texture_path = self._vmt.get_string('$basetexture', None)
+        if texture_path is not None:
+            return self.load_texture_or_default(texture_path, (0.3, 0, 0.3, 1.0))
+        return None
+
+    @property
+    def texture2(self):
+        texture_path = self._vmt.get_string('$texture2', None)
+        if texture_path is not None:
+            image = self.load_texture_or_default(texture_path, (0.0, 0.0, 0.0, 1.0))
+            image.colorspace_settings.is_data = True
+            image.colorspace_settings.name = 'Non-Color'
+            return image
+        return None
+
+    @property
+    def color2(self):
+        color_value, value_type = self._vmt.get_vector('$color2', [1, 1, 1])
+        divider = 255 if value_type is int else 1
+        color_value = list(map(lambda a: a / divider, color_value))
+        if len(color_value) == 1:
+            color_value = [color_value[0], color_value[0], color_value[0]]
+        elif len(color_value) > 3:
+            color_value = color_value[:3]
+        return color_value
+
+    @property
+    def color(self):
+        color_value, value_type = self._vmt.get_vector('$color', [1, 1, 1])
+        divider = 255 if value_type is int else 1
+        color_value = list(map(lambda a: a / divider, color_value))
+        if len(color_value) == 1:
+            color_value = [color_value[0], color_value[0], color_value[0]]
+        elif len(color_value) > 3:
+            color_value = color_value[:3]
+        return color_value
+
+    @property
+    def additive(self):
+        return self._vmt.get_int('$additive', 0) == 1
+    
+    @property
+    def mod2x(self):
+        return self._vmt.get_int('$mod2x', 0) == 1
+
+    @property
+    def translucent(self):
+        return self._vmt.get_int('$translucent', 0) == 1
+    
+    @property
+    def nocull(self):
+        return self._vmt.get_int('$nocull', 0) == 1
+
+    def create_nodes(self, material):
+        if super().create_nodes(material) in ['UNKNOWN', 'LOADED']:
+            return
+        mult = self.create_node(Nodes.ShaderNodeVectorMath)
+        mult.inputs[0].default_value = (1, 1, 1)
+        mult.inputs[1].default_value = (1, 1, 1)
+        if self.basetexture:
+            basetexture_node = self.create_texture_node(self.basetexture)
+            self.connect_nodes(basetexture_node.outputs[0], mult.inputs[0])
+        if self.mod2x:
+            mult.inputs[1].default_value = (2, 2, 2)
+        self.bpy_material.use_backface_culling = self.nocull
+        transparent = self.create_nodes(Nodes.ShaderNodeBsdfTransparent)
+        self.connect_nodes(mult.outputs[0], transparent.inputs[0])
+        out = self.create_node(Nodes.ShaderNodeOutputMaterial)
+        self.connect_nodes(transparent.outputs[0], out.inputs[0])

--- a/blender_bindings/material_loader/shaders/source1_shaders/modulate.py
+++ b/blender_bindings/material_loader/shaders/source1_shaders/modulate.py
@@ -1,4 +1,3 @@
-from SourceIO.blender_bindings.utils.bpy_utils import is_blender_4
 from ...shader_base import Nodes
 from ..source1_shader_base import Source1ShaderBase
 
@@ -64,7 +63,10 @@ class Modulate(Source1ShaderBase):
     def create_nodes(self, material):
         if super().create_nodes(material) in ['UNKNOWN', 'LOADED']:
             return
+        self.bpy_material.blend_method = 'BLEND'
+        self.bpy_material.surface_render_method = 'BLENDED'
         mult = self.create_node(Nodes.ShaderNodeVectorMath)
+        mult.operation = 'MULTIPLY'
         mult.inputs[0].default_value = (1, 1, 1)
         mult.inputs[1].default_value = (1, 1, 1)
         if self.basetexture:
@@ -73,7 +75,7 @@ class Modulate(Source1ShaderBase):
         if self.mod2x:
             mult.inputs[1].default_value = (2, 2, 2)
         self.bpy_material.use_backface_culling = self.nocull
-        transparent = self.create_nodes(Nodes.ShaderNodeBsdfTransparent)
+        transparent = self.create_node(Nodes.ShaderNodeBsdfTransparent)
         self.connect_nodes(mult.outputs[0], transparent.inputs[0])
         out = self.create_node(Nodes.ShaderNodeOutputMaterial)
         self.connect_nodes(transparent.outputs[0], out.inputs[0])

--- a/blender_bindings/material_loader/shaders/source1_shaders/modulate.py
+++ b/blender_bindings/material_loader/shaders/source1_shaders/modulate.py
@@ -74,7 +74,7 @@ class Modulate(Source1ShaderBase):
             self.connect_nodes(basetexture_node.outputs[0], mult.inputs[0])
         if self.mod2x:
             mult.inputs[1].default_value = (2, 2, 2)
-        self.bpy_material.use_backface_culling = self.nocull
+        self.bpy_material.use_backface_culling = not bool(self.nocull)
         transparent = self.create_node(Nodes.ShaderNodeBsdfTransparent)
         self.connect_nodes(mult.outputs[0], transparent.inputs[0])
         out = self.create_node(Nodes.ShaderNodeOutputMaterial)

--- a/blender_bindings/material_loader/shaders/source1_shaders/unlittwotexture.py
+++ b/blender_bindings/material_loader/shaders/source1_shaders/unlittwotexture.py
@@ -58,14 +58,11 @@ class UnlitGeneric(Source1ShaderBase):
         return self._vmt.get_int('$nocull', 0) == 1
 
     def create_nodes(self, material):
-        vertical = 0
         self.do_arrange = True
         if super().create_nodes(material) in ['UNKNOWN', 'LOADED']:
             return
 
         material_output = self.create_node(Nodes.ShaderNodeOutputMaterial)
-        #shader = self.create_node(Nodes.ShaderNodeBsdfPrincipled, self.SHADER)
-        #self.connect_nodes(shader.outputs['BSDF'], material_output.inputs['Surface'])
 
         basetexture = self.basetexture
         texture2 = self.texture2
@@ -75,13 +72,9 @@ class UnlitGeneric(Source1ShaderBase):
             self.bpy_material.use_backface_culling = True
         if basetexture:
             basetexture_node = self.create_and_connect_texture_node(basetexture, name='$basetexture')
-            basetexture_node.location = [0, 0]
             if texture2:
                 texture2_node = self.create_and_connect_texture_node(texture2, name='$basetexture')
-                texture2_node.location = [0, -300]
-                vertical += 300
                 color_mix = self.create_node(Nodes.ShaderNodeMixRGB)
-                color_mix.location = [vertical, 0]
                 color_mix.blend_type = 'MULTIPLY'
                 color_mix.inputs['Fac'].default_value = 1.0
                 self.connect_nodes(basetexture_node.outputs['Color'], color_mix.inputs['Color1'])
@@ -91,7 +84,6 @@ class UnlitGeneric(Source1ShaderBase):
                 texture_output = basetexture_node.outputs['Color']
 
             if self.color or self.color2:
-                #vertical += 300
                 color_mix = self.create_node(Nodes.ShaderNodeMixRGB)
                 color_mix.location
                 color_mix.blend_type = 'MULTIPLY'
@@ -99,10 +91,8 @@ class UnlitGeneric(Source1ShaderBase):
                 color_mix.inputs['Color2'].default_value = (*(self.color or self.color2), 1.0)
                 color_mix.inputs['Fac'].default_value = 1.0
                 texture_output = color_mix.outputs[0]
-                #self.connect_nodes(color_mix.outputs['Color'], shader.inputs['Base Color'])
             else:
                 pass
-                #self.connect_nodes(texture_output, shader.inputs['Base Color'])
         if self.additive:
             self.bpy_material.blend_method = 'BLEND'
             self.bpy_material.surface_render_method = 'BLENDED'

--- a/blender_bindings/material_loader/shaders/source1_shaders/unlittwotexture.py
+++ b/blender_bindings/material_loader/shaders/source1_shaders/unlittwotexture.py
@@ -48,23 +48,40 @@ class UnlitGeneric(Source1ShaderBase):
     @property
     def additive(self):
         return self._vmt.get_int('$additive', 0) == 1
+    
+    @property
+    def translucent(self):
+        return self._vmt.get_int('$translucent', 0) == 1
+    
+    @property
+    def nocull(self):
+        return self._vmt.get_int('$nocull', 0) == 1
 
     def create_nodes(self, material):
+        vertical = 0
+        self.do_arrange = True
         if super().create_nodes(material) in ['UNKNOWN', 'LOADED']:
             return
 
         material_output = self.create_node(Nodes.ShaderNodeOutputMaterial)
-        shader = self.create_node(Nodes.ShaderNodeBsdfPrincipled, self.SHADER)
-        self.connect_nodes(shader.outputs['BSDF'], material_output.inputs['Surface'])
+        #shader = self.create_node(Nodes.ShaderNodeBsdfPrincipled, self.SHADER)
+        #self.connect_nodes(shader.outputs['BSDF'], material_output.inputs['Surface'])
 
         basetexture = self.basetexture
         texture2 = self.texture2
+        if self.nocull:
+            self.bpy_material.use_backface_culling = False
+        else:
+            self.bpy_material.use_backface_culling = True
         if basetexture:
             basetexture_node = self.create_and_connect_texture_node(basetexture, name='$basetexture')
+            basetexture_node.location = [0, 0]
             if texture2:
                 texture2_node = self.create_and_connect_texture_node(texture2, name='$basetexture')
-
+                texture2_node.location = [0, -300]
+                vertical += 300
                 color_mix = self.create_node(Nodes.ShaderNodeMixRGB)
+                color_mix.location = [vertical, 0]
                 color_mix.blend_type = 'MULTIPLY'
                 color_mix.inputs['Fac'].default_value = 1.0
                 self.connect_nodes(basetexture_node.outputs['Color'], color_mix.inputs['Color1'])
@@ -74,28 +91,40 @@ class UnlitGeneric(Source1ShaderBase):
                 texture_output = basetexture_node.outputs['Color']
 
             if self.color or self.color2:
+                #vertical += 300
                 color_mix = self.create_node(Nodes.ShaderNodeMixRGB)
+                color_mix.location
                 color_mix.blend_type = 'MULTIPLY'
                 self.connect_nodes(texture_output, color_mix.inputs['Color1'])
                 color_mix.inputs['Color2'].default_value = (*(self.color or self.color2), 1.0)
                 color_mix.inputs['Fac'].default_value = 1.0
-                self.connect_nodes(color_mix.outputs['Color'], shader.inputs['Base Color'])
+                texture_output = color_mix.outputs[0]
+                #self.connect_nodes(color_mix.outputs['Color'], shader.inputs['Base Color'])
             else:
-                self.connect_nodes(texture_output, shader.inputs['Base Color'])
-            if self.additive:
-                if self.additive:
-                    basetexture_invert_node = self.create_node(Nodes.ShaderNodeInvert)
-                    basetexture_additive_mix_node = self.create_node(Nodes.ShaderNodeMixRGB)
+                pass
+                #self.connect_nodes(texture_output, shader.inputs['Base Color'])
+        if self.additive:
+            self.bpy_material.blend_method = 'BLEND'
+            self.bpy_material.surface_render_method = 'BLENDED'
 
-                    self.insert_node(texture_output, basetexture_additive_mix_node.inputs['Color1'],
-                                     basetexture_additive_mix_node.outputs['Color'])
-                    basetexture_additive_mix_node.inputs['Color2'].default_value = (1.0, 1.0, 1.0, 1.0)
+            transparent = self.create_node(Nodes.ShaderNodeBsdfTransparent)
+            add_shader = self.create_node(Nodes.ShaderNodeAddShader)
 
-                    self.connect_nodes(texture_output, basetexture_invert_node.inputs['Color'])
-                    if is_blender_4():
-                        self.connect_nodes(basetexture_invert_node.outputs['Color'],
-                                           shader.inputs['Transmission Weight'])
-                    else:
-                        self.connect_nodes(basetexture_invert_node.outputs['Color'], shader.inputs['Transmission'])
-                    self.connect_nodes(basetexture_invert_node.outputs['Color'],
-                                       basetexture_additive_mix_node.inputs['Fac'])
+            self.connect_nodes(transparent.outputs[0], add_shader.inputs[0])
+            self.connect_nodes(texture_output, add_shader.inputs[1])
+
+            texture_output = add_shader.outputs[0]
+        
+        if self.translucent:
+            self.bpy_material.blend_method = 'BLEND'
+            self.bpy_material.surface_render_method = 'BLENDED'
+
+            mix = self.create_node(Nodes.ShaderNodeMixShader)
+            transparent = self.create_node(Nodes.ShaderNodeBsdfTransparent)
+
+            self.connect_nodes(texture_output, mix.inputs[2])
+            self.connect_nodes(transparent.outputs[0], mix.inputs[1])
+            self.connect_nodes(basetexture_node.outputs[1], mix.inputs[0])
+            texture_output = mix.outputs[0]
+
+        self.connect_nodes(texture_output, material_output.inputs[0])

--- a/blender_bindings/material_loader/shaders/source1_shaders/unlittwotexture.py
+++ b/blender_bindings/material_loader/shaders/source1_shaders/unlittwotexture.py
@@ -73,7 +73,7 @@ class UnlitGeneric(Source1ShaderBase):
         if basetexture:
             basetexture_node = self.create_and_connect_texture_node(basetexture, name='$basetexture')
             if texture2:
-                texture2_node = self.create_and_connect_texture_node(texture2, name='$basetexture')
+                texture2_node = self.create_and_connect_texture_node(texture2, name='$texture2')
                 color_mix = self.create_node(Nodes.ShaderNodeMixRGB)
                 color_mix.blend_type = 'MULTIPLY'
                 color_mix.inputs['Fac'].default_value = 1.0

--- a/blender_bindings/material_loader/shaders/source1_shaders/vertexlit_generic.py
+++ b/blender_bindings/material_loader/shaders/source1_shaders/vertexlit_generic.py
@@ -423,6 +423,12 @@ class VertexLitGeneric(DetailSupportMixin, Source1ShaderBase):
                     self.connect_nodes(transparent.outputs[0], add_cycles.inputs[0])
                     final = add_eevee.outputs[0]
                     final_cycles = add_cycles.outputs[0]
+                else:
+                    add = self.create_node(Nodes.ShaderNodeAddShader)
+                    transparent = self.create_node(Nodes.ShaderNodeBsdfTransparent)
+                    self.connect_nodes(final, add_eevee.inputs[1])
+                    self.connect_nodes(transparent.outputs[0], add.inputs[0])
+                    final = add.outputs[0]
                     
             if self.alphatest or self.translucent:
                 alphatest_node = self.create_node_group("$alphatest", [250, 0])

--- a/blender_bindings/material_loader/shaders/source1_shaders/vertexlit_generic.py
+++ b/blender_bindings/material_loader/shaders/source1_shaders/vertexlit_generic.py
@@ -2,7 +2,6 @@ from ....utils.bpy_utils import is_blender_4
 from ...shader_base import Nodes
 from ..source1_shader_base import Source1ShaderBase
 from .detail import DetailSupportMixin
-import bpy
 
 class VertexLitGeneric(DetailSupportMixin, Source1ShaderBase):
     SHADER: str = 'vertexlitgeneric'
@@ -268,21 +267,8 @@ class VertexLitGeneric(DetailSupportMixin, Source1ShaderBase):
                         self._vmt[result_var] = self._vmt[src2_var]
 
 
-
-        if (items := self._vmt.get('>=dx90')) or (items := self._vmt.get('>=DX90')):
-            #print('true!')
-            #print(items, dir(items), list(items.items()))
-            for item_name, item_value in items.items():
-                #print(item_name, item_value)
-                self._vmt[item_name] = item_value
-                if item_name == '$selfillum' and item_value == '1':
-                    selfillum = True
-
-        selfillum = self.selfillum or selfillum
-
         material_output = self.create_node(Nodes.ShaderNodeOutputMaterial)
         material_output.location = [250, 0]
-        parentnode = material_output
 
         if self.alphatest or self.translucent:
             if self.translucent:
@@ -414,7 +400,7 @@ class VertexLitGeneric(DetailSupportMixin, Source1ShaderBase):
                 cycles_output = self.create_node(Nodes.ShaderNodeOutputMaterial, name='Cycles Output')
                 cycles_output.target = 'CYCLES'
 
-                lightwarp: bpy.types.ShaderNodeTexImage = self.create_texture_node(self.lightwarptexture, 'lightwarptexture')
+                lightwarp = self.create_texture_node(self.lightwarptexture, 'lightwarptexture')
                 lightwarp.extension = 'EXTEND'
                 self.connect_nodes(group_node.outputs['lightwarpvector'], lightwarp.inputs[0])
                 sio_diffuse = self.create_node_group('SIO-Diffuse', name='Diffuse')

--- a/blender_bindings/models/mdl36/__init__.py
+++ b/blender_bindings/models/mdl36/__init__.py
@@ -30,6 +30,14 @@ def import_mdl36(model_path: TinyPath, buffer: Buffer,
         raise RequiredFileNotFound(f"Could not find VVD file for {model_path}")
     vtx = open_vtx(vtx_buffer)
 
+    if options.import_textures:
+        try:
+            import_materials(content_manager, mdl, use_bvlg=options.use_bvlg)
+        except Exception as t_ex:
+            logger.error(f'Failed to import materials, caused by {t_ex}')
+            import traceback
+            traceback.print_exc()
+
     container = import_model(content_manager, mdl, vtx, options.scale, options.create_flex_drivers)
     if options.import_physics:
         phy_buffer = content_manager.find_file(model_path.with_suffix(".phy"))
@@ -38,11 +46,5 @@ def import_mdl36(model_path: TinyPath, buffer: Buffer,
         else:
             phy = Phy.from_buffer(phy_buffer)
             import_physics(phy, phy_buffer, mdl, container, options.scale)
-    if options.import_textures:
-        try:
-            import_materials(content_manager, mdl, use_bvlg=options.use_bvlg)
-        except Exception as t_ex:
-            logger.error(f'Failed to import materials, caused by {t_ex}')
-            import traceback
-            traceback.print_exc()
+    
     return container

--- a/blender_bindings/models/mdl44/__init__.py
+++ b/blender_bindings/models/mdl44/__init__.py
@@ -39,7 +39,13 @@ def import_mdl44(model_path: TinyPath, buffer: Buffer,
         raise RequiredFileNotFound(f"Could not find VTX and/or VVD file for {model_path}")
     vtx = open_vtx(vtx_buffer)
     vvd = Vvd.from_buffer(vvd_buffer)
-
+    if options.import_textures:
+        try:
+            import_materials(content_manager, mdl, use_bvlg=options.use_bvlg)
+        except Exception as t_ex:
+            logger.error(f'Failed to import materials, caused by {t_ex}')
+            import traceback
+            traceback.print_exc()
     container = import_model(content_manager, mdl, vtx, vvd, options.scale, options.create_flex_drivers)
     if options.import_physics:
         phy_buffer = content_manager.find_file(model_path.with_suffix(".phy"))
@@ -48,12 +54,6 @@ def import_mdl44(model_path: TinyPath, buffer: Buffer,
         else:
             phy = Phy.from_buffer(phy_buffer)
             import_physics(phy, phy_buffer, mdl, container, options.scale)
-    if options.import_textures:
-        try:
-            import_materials(content_manager, mdl, use_bvlg=options.use_bvlg)
-        except Exception as t_ex:
-            logger.error(f'Failed to import materials, caused by {t_ex}')
-            import traceback
-            traceback.print_exc()
+    
 
     return container

--- a/blender_bindings/models/mdl44/import_mdl.py
+++ b/blender_bindings/models/mdl44/import_mdl.py
@@ -105,7 +105,19 @@ def import_model(content_manager: ContentManager, mdl: MdlV44, vtx: Vtx, vvd: Vv
 
             mesh_data = bpy.data.meshes.new(f'{mesh_name}_MESH')
             mesh_obj = bpy.data.objects.new(mesh_name, mesh_data)
-            mesh_obj['skin_groups'] = {str(n): group for (n, group) in enumerate(mdl.skin_groups)}
+            if getattr(mdl, 'material_mapper', None):
+                material_mapper = mdl.material_mapper
+                print(mdl, material_mapper)
+                true_skin_groups = {str(n): list(map(lambda a: material_mapper.get(a.material_pointer), group)) for (n, group) in enumerate(mdl.skin_groups)}
+                for key, value in true_skin_groups.items():
+                    while None in value:
+                        value.remove(None)
+                try:
+                    mesh_obj['skin_groups'] = true_skin_groups
+                except:
+                    mesh_obj['skin_groups'] = {str(n): list(map(lambda a: a.name, group)) for (n, group) in enumerate(mdl.skin_groups)}
+            else:
+                mesh_obj['skin_groups'] = {str(n): list(map(lambda a: a.name, group)) for (n, group) in enumerate(mdl.skin_groups)}
             mesh_obj['active_skin'] = '0'
             mesh_obj['model_type'] = 's1'
             objects.append(mesh_obj)

--- a/blender_bindings/models/mdl49/__init__.py
+++ b/blender_bindings/models/mdl49/__init__.py
@@ -37,6 +37,14 @@ def import_mdl49(model_path: TinyPath, buffer: Buffer,
     vtx = open_vtx(vtx_buffer)
     vvd = Vvd.from_buffer(vvd_buffer)
 
+    if options.import_textures:
+        try:
+            import_materials(content_manager, mdl, use_bvlg=options.use_bvlg)
+        except Exception as t_ex:
+            logger.error(f'Failed to import materials, caused by {t_ex}')
+            import traceback
+            traceback.print_exc()
+
     container = import_model(content_manager, mdl, vtx, vvd, options.scale, options.create_flex_drivers)
     if options.import_physics:
         phy_buffer = content_manager.find_file(model_path.with_suffix(".phy"))
@@ -46,13 +54,7 @@ def import_mdl49(model_path: TinyPath, buffer: Buffer,
             phy = Phy.from_buffer(phy_buffer)
             import_physics(phy, phy_buffer, mdl, container, options.scale)
 
-    if options.import_textures:
-        try:
-            import_materials(content_manager, mdl, use_bvlg=options.use_bvlg)
-        except Exception as t_ex:
-            logger.error(f'Failed to import materials, caused by {t_ex}')
-            import traceback
-            traceback.print_exc()
+    
     if options.import_animations and container.armature:
         import_animations(content_manager, mdl, container.armature, options.scale)
     return container

--- a/blender_bindings/models/mdl49/import_mdl.py
+++ b/blender_bindings/models/mdl49/import_mdl.py
@@ -58,7 +58,18 @@ def import_model(content_manager: ContentManager, mdl: MdlV49, vtx: Vtx, vvd: Vv
 
             mesh_data = bpy.data.meshes.new(mesh_name)
             mesh_obj = bpy.data.objects.new(object_name, mesh_data)
-            mesh_obj['skin_groups'] = {str(n): group for (n, group) in enumerate(mdl.skin_groups)}
+            if getattr(mdl, 'material_mapper', None):
+                material_mapper = mdl.material_mapper
+                true_skin_groups = {str(n): list(map(lambda a: material_mapper.get(a.material_pointer), group)) for (n, group) in enumerate(mdl.skin_groups)}
+                for key, value in true_skin_groups.items():
+                    while None in value:
+                        value.remove(None)
+                try:
+                    mesh_obj['skin_groups'] = true_skin_groups
+                except:
+                    mesh_obj['skin_groups'] = {str(n): list(map(lambda a: a.name, group)) for (n, group) in enumerate(mdl.skin_groups)}
+            else:
+                mesh_obj['skin_groups'] = {str(n): list(map(lambda a: a.name, group)) for (n, group) in enumerate(mdl.skin_groups)}
             mesh_obj['active_skin'] = '0'
             mesh_obj['model_type'] = 's1'
 

--- a/blender_bindings/models/mdl52/__init__.py
+++ b/blender_bindings/models/mdl52/__init__.py
@@ -39,6 +39,14 @@ def import_mdl52(model_path: TinyPath, buffer: Buffer,
     else:
         vvc = None
 
+    if options.import_textures:
+        try:
+            import_materials(content_manager, mdl, use_bvlg=options.use_bvlg)
+        except Exception as t_ex:
+            logger.error(f'Failed to import materials, caused by {t_ex}')
+            import traceback
+            traceback.print_exc()
+
     container = import_model(content_manager, mdl, vtx, vvd, vvc, options.scale)
     if options.import_physics:
         phy_buffer = content_manager.find_file(model_path.with_suffix(".phy"))
@@ -48,11 +56,5 @@ def import_mdl52(model_path: TinyPath, buffer: Buffer,
             phy = Phy.from_buffer(phy_buffer)
             import_physics(phy, phy_buffer, mdl, container, options.scale)
 
-    if options.import_textures:
-        try:
-            import_materials(content_manager, mdl, use_bvlg=options.use_bvlg)
-        except Exception as t_ex:
-            logger.error(f'Failed to import materials, caused by {t_ex}')
-            import traceback
-            traceback.print_exc()
+    
     return container

--- a/blender_bindings/models/mdl52/import_mdl.py
+++ b/blender_bindings/models/mdl52/import_mdl.py
@@ -50,7 +50,18 @@ def import_model(content_provider: ContentProvider, mdl: MdlV52, vtx: Vtx, vvd: 
 
             mesh_data = bpy.data.meshes.new(f'{mesh_name}_MESH')
             mesh_obj = bpy.data.objects.new(mesh_name, mesh_data)
-            mesh_obj['skin_groups'] = {str(n): group for (n, group) in enumerate(mdl.skin_groups)}
+            if getattr(mdl, 'material_mapper', None):
+                material_mapper = mdl.material_mapper
+                true_skin_groups = {str(n): list(map(lambda a: material_mapper.get(a.material_pointer), group)) for (n, group) in enumerate(mdl.skin_groups)}
+                for key, value in true_skin_groups.items():
+                    while None in value:
+                        value.remove(None)
+                try:
+                    mesh_obj['skin_groups'] = true_skin_groups
+                except:
+                    mesh_obj['skin_groups'] = {str(n): list(map(lambda a: a.name, group)) for (n, group) in enumerate(mdl.skin_groups)}
+            else:
+                mesh_obj['skin_groups'] = {str(n): list(map(lambda a: a.name, group)) for (n, group) in enumerate(mdl.skin_groups)}
             mesh_obj['active_skin'] = '0'
             mesh_obj['model_type'] = 's1'
 

--- a/blender_bindings/operators/shared_operators.py
+++ b/blender_bindings/operators/shared_operators.py
@@ -338,17 +338,15 @@ class SOURCEIO_OT_ChangeSkin(Operator):
     def handle_s1(self, obj):
         prop_path = TinyPath(obj['prop_path'])
         skin_materials = obj['skin_groups'][self.skin_name]
-        current_materials = obj['skin_groups'][obj['active_skin']]
-        unique_material_names = obj['unique_material_names']
-        for skin_material, current_material in zip(skin_materials, current_materials):
-            if unique_material_names:
-                skin_material = f"{prop_path.stem}_{skin_material[:63]}"[:63]
-                current_material = f"{prop_path.stem}_{current_material[:63]}"[:63]
-            else:
-                skin_material = skin_material[:63]
-                current_material = current_material[:63]
+        old_skins = obj['skin_groups'][obj['active_skin']]
 
-            swap_materials(obj, skin_material, current_material)
+        remap = {old: new for old, new in zip(old_skins, skin_materials)}
+
+        for n, mat in enumerate(obj.data.materials):
+            if (replacement := remap.get(mat)) == None: continue
+            obj.data.materials[n] = replacement
+
+        del remap
 
     def handle_s2(self, obj):
         skin_material = obj['skin_groups'][self.skin_name]

--- a/blender_bindings/operators/source1_operators.py
+++ b/blender_bindings/operators/source1_operators.py
@@ -184,7 +184,7 @@ class SOURCEIO_OT_SkyboxImport(ImportOperatorHelper):
 
     def execute(self, context):
         directory = self.get_directory()
-        content_manager = StandaloneContentProvider()
+        content_manager = ContentManager()
         if self.discover_resources:
             content_manager.scan_for_content(directory)
             serialize_mounted_content(content_manager)
@@ -215,7 +215,7 @@ class SOURCEIO_OT_VMTImport(ImportOperatorHelper):
 
     def execute(self, context):
         directory = self.get_directory()
-        content_manager = StandaloneContentProvider()
+        content_manager = ContentManager()
         if self.discover_resources:
             content_manager.scan_for_content(directory)
             serialize_mounted_content(content_manager)
@@ -226,7 +226,7 @@ class SOURCEIO_OT_VMTImport(ImportOperatorHelper):
             Source1ShaderBase.use_bvlg(self.use_bvlg)
             file_path = TinyPath(file.name)
             mat = get_or_create_material(file_path.stem, file_path.as_posix())
-            loader = Source1MaterialLoader((directory / file.name).open('rb'), file_path.stem)
+            loader = Source1MaterialLoader(content_manager, (directory / file.name).open('rb'), file_path.stem)
             bpy_material = bpy.data.materials.get(loader.material_name, dict())
             if bpy_material.get('source_loaded'):
                 if self.override:

--- a/blender_bindings/operators/source1_operators.py
+++ b/blender_bindings/operators/source1_operators.py
@@ -37,6 +37,7 @@ class SOURCEIO_OT_MDLImport(ImportOperatorHelper, ModelOptions):
     filter_glob: StringProperty(default="*.mdl;*.md3", options={'HIDDEN'})
 
     def execute(self, context):
+        
         directory = self.get_directory()
 
         content_manager = ContentManager()

--- a/blender_bindings/utils/texture_utils.py
+++ b/blender_bindings/utils/texture_utils.py
@@ -64,6 +64,7 @@ def check_texture_cache(texture_path: TinyPath) -> Optional[bpy.types.Image]:
     logger.info(f"Loaded {texture_path!r} texture from disc")
     image.alpha_mode = "CHANNEL_PACKED"
     image.name = texture_path.stem
+    image['full_path'] = texture_path.lower()
     return image
 
 

--- a/library/models/mdl/structs/material.py
+++ b/library/models/mdl/structs/material.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from uuid import uuid4
 
 
 from SourceIO.library.utils import Buffer

--- a/library/models/mdl/structs/material.py
+++ b/library/models/mdl/structs/material.py
@@ -47,6 +47,9 @@ class MaterialV49(Material):
         used = buffer.read_uint32()
         unused1 = buffer.read_uint32()
         material_pointer = buffer.read_uint32()
+        material_pointer = str(uuid4())
+        # hey REDxEYE
+        # this works to store all skin groups as material IDs instead of str. using the buffer doesn't work anyways.
         client_material_pointer = buffer.read_uint32()
         buffer.skip((10 if version < 53 else 5) * 4)
         return cls(name, flags, used, unused1, material_pointer, client_material_pointer)

--- a/library/models/mdl/v36/mdl_file.py
+++ b/library/models/mdl/v36/mdl_file.py
@@ -60,7 +60,7 @@ class MdlV36(Mdl):
             skin_group = []
             for _ in range(header.skin_reference_count):
                 texture_index = buffer.read_uint16()
-                skin_group.append(materials[texture_index].name)
+                skin_group.append(materials[texture_index])
             skin_groups.append(skin_group)
 
         diff_start = 0

--- a/library/models/mdl/v44/mdl_file.py
+++ b/library/models/mdl/v44/mdl_file.py
@@ -80,7 +80,7 @@ class MdlV44(Mdl):
             skin_group = []
             for _ in range(header.skin_reference_count):
                 texture_index = buffer.read_uint16()
-                skin_group.append(materials[texture_index].name)
+                skin_group.append(materials[texture_index])
             skin_groups.append(skin_group)
 
         diff_start = 0

--- a/library/models/mdl/v49/mdl_file.py
+++ b/library/models/mdl/v49/mdl_file.py
@@ -51,7 +51,7 @@ class MdlV49(MdlV44):
             skin_group = []
             for _ in range(header.skin_reference_count):
                 texture_index = buffer.read_uint16()
-                skin_group.append(materials[texture_index].name)
+                skin_group.append(materials[texture_index])
             skin_groups.append(skin_group)
 
         diff_start = 0

--- a/library/utils/kv_parser.py
+++ b/library/utils/kv_parser.py
@@ -120,7 +120,12 @@ class KVDataProxy(Mapping):
         for k, v in self.items():
             if isinstance(v, KVDataProxy):
                 v = v.to_dict()
-            items[k] = v
+            if items.get(k) != None and isinstance(v, dict):
+                if not isinstance(items[k], list):
+                    items[k] = [items[k]]
+                items[k].append(v)
+            else:
+                items[k] = v
         return items
 
 


### PR DESCRIPTION
# Better Materials
(left is new, right is old)
- Shader Fixes/Additions
  - VertexLitGeneric
    - Received Lightwarp support (see the cel shading on Heavy's skin)
    - Better transparency and additive implementation (see the glow on Bolt Boy cosmetic)
    - Less broken paint regions (see the Bolt Boy cosmetic)
  - UnlitTwoTexture
    - Better implementation (see the sun beams and the capture point holograms)
  - Modulate shader added
![image](https://github.com/user-attachments/assets/6fe66490-3f52-482d-b749-6faa370b2b55)
- Shader General
  - Shader name and vmt parameters are stored as custom properties for materials
  - dx90 parameters are unraveled and saved into the main parameters instead
# mdl porting
- .mdl importing
  - Changed the skin group saving method to save the actual material IDs instead of their names
    - REDxEYE, I swear the only way this could be implemented was to use a pseudo-pointer for materials. Using from the buffer never worked, so I used a uuid4 string instead. It works?

