### PR TITLE
Fixed goldsrc bsp import on Linux

### DIFF
--- a/blender_bindings/goldsrc/bsp/import_bsp.py
+++ b/blender_bindings/goldsrc/bsp/import_bsp.py
@@ -244,7 +244,7 @@ class BSP:
                     for game_wad_path in entity.get('wad', '').split(';'):
                         if len(game_wad_path) == 0:
                             continue
-                        game_wad_path = backwalk_file_resolver(self.map_path.parent, TinyPath(game_wad_path))
+                        game_wad_path = backwalk_file_resolver(self.map_path.parent, TinyPath(game_wad_path).lstrip('/'))
                         if game_wad_path is not None and game_wad_path.exists():
                             self.bsp_file.manager.add_child(GoldSrcWADContentProvider(game_wad_path))
                 elif entity_class.startswith('monster_') and 'model' in entity:


### PR DESCRIPTION
Pretty hacky, just clobbers left-most slashes in bsp datablobs to avoid being flagged as an absolute file path.

Tested on various maps and seems to work great though.