### PR TITLE
fix: materials importing as blank white models (silent shader pipeline failures)

### DIFF
--- a/blender_bindings/material_loader/material_loader.py
+++ b/blender_bindings/material_loader/material_loader.py
@@ -54,24 +54,26 @@ class ShaderRegistry:
                              extra_parameters: dict[ExtraMaterialParameters, Any]):
         if not cls._initial_setup(material):
             return material
-        
+
         shader = vmt.shader
         if shader not in cls._handlers:
-            logger.error(f'Shader "{shader}" not currently supported by SourceIO')
+            logger.error(f'Shader "{shader}" not currently supported by SourceIO, using fallback')
 
         handler: Source1ShaderBase = cls._handlers.get(shader, Source1ShaderBase)(content_manager, vmt)
         handler.bpy_material = material
         try:
-            new_material = handler.create_nodes(material, extra_parameters) or material # support material templates
+            new_material = handler.create_nodes(material, extra_parameters) or material
             if not isinstance(new_material, bpy.types.Material):
                 new_material = material
             material = new_material
+            material['source_loaded'] = True
 
         except Exception as e:
-            logger.error(f'Failed to load material, due to {e} error')
+            logger.error(f'Failed to load material "{material.name}", due to {e} error')
             traceback.print_exc()
-            logger.debug(f'Failed material: {material.name}')
-        # params = handler._vmt.data.to_dict()
+            # Allow retry by not setting source_loaded
+            if 'source_loaded' in material:
+                del material['source_loaded']
         material['vmt_parameters'] = vmt.data.to_dict()
         if handler.do_arrange:
             handler.align_nodes()
@@ -96,10 +98,12 @@ class ShaderRegistry:
         handler.bpy_material = material
         try:
             handler.create_nodes(material, extra_parameters)
+            material['source_loaded'] = True
         except Exception as e:
-            logger.error(f'Failed to load material, due to {e} error')
+            logger.error(f'Failed to load material "{material.name}", due to {e} error')
             traceback.print_exc()
-            logger.debug(f'Failed material: {material.name}')
+            if 'source_loaded' in material:
+                del material['source_loaded']
         cls.align_nodes(material)
         for unused_texture in handler.unused_textures.copy():
             texture_path = material_resource.get_texture_property(unused_texture, None)
@@ -112,8 +116,6 @@ class ShaderRegistry:
         if material.get('source_loaded', False):
             return False
 
-        material.use_nodes = True
-        material['source_loaded'] = True
         material.use_nodes = True
         cls._clean_nodes(material)
         if not is_blender_4_3():

--- a/blender_bindings/material_loader/shaders/source1_shader_base.py
+++ b/blender_bindings/material_loader/shaders/source1_shader_base.py
@@ -1,7 +1,9 @@
+from typing import Any
+
 import bpy
 import numpy as np
 
-from SourceIO.blender_bindings.material_loader.shader_base import ShaderBase
+from SourceIO.blender_bindings.material_loader.shader_base import ShaderBase, Nodes, ExtraMaterialParameters
 from SourceIO.blender_bindings.source1.vtf import import_texture
 from SourceIO.blender_bindings.utils.texture_utils import check_texture_cache
 from SourceIO.library.shared.content_manager import ContentManager
@@ -16,11 +18,36 @@ class Source1ShaderBase(ShaderBase):
         self.content_manager = content_manager
         self.load_bvlg_nodes()
         if (dx90 := (vmt.get('>=dx90') or vmt.get('>=DX90'))):
-            # unravel it, because we want dx90 properties
             for key, value in dx90.items():
                 vmt[key] = value
         self._vmt: VMT = vmt
         self.textures = {}
+
+    def create_nodes(self, material: bpy.types.Material, extra_parameters: dict[ExtraMaterialParameters, Any]):
+        """Fallback shader: creates a basic Principled BSDF with $basetexture if available."""
+        self.logger.warn(f'Using fallback shader for "{self._vmt.shader}", creating basic Principled BSDF')
+        material_output = self.create_node(Nodes.ShaderNodeOutputMaterial)
+        material_output.location = [250, 0]
+        shader = self.create_node(Nodes.ShaderNodeBsdfPrincipled, 'Fallback BSDF')
+        self.connect_nodes(shader.outputs['BSDF'], material_output.inputs['Surface'])
+
+        texture_path = self._vmt.get_string('$basetexture', None)
+        if texture_path is not None:
+            basetexture = self.load_texture_or_default(texture_path, (0.5, 0.5, 0.5, 1.0))
+            basetexture_node = self.create_node(Nodes.ShaderNodeTexImage, '$basetexture')
+            basetexture_node.image = basetexture
+            self.connect_nodes(basetexture_node.outputs['Color'], shader.inputs['Base Color'])
+
+        bumpmap_path = self._vmt.get_string('$bumpmap', None)
+        if bumpmap_path is not None:
+            bumpmap = self.load_texture_or_default(bumpmap_path, (0.5, 0.5, 1.0, 1.0))
+            bumpmap.colorspace_settings.is_data = True
+            bumpmap.colorspace_settings.name = 'Non-Color'
+            bumpmap_node = self.create_node(Nodes.ShaderNodeTexImage, '$bumpmap')
+            bumpmap_node.image = bumpmap
+            normalmap_node = self.create_node(Nodes.ShaderNodeNormalMap)
+            self.connect_nodes(bumpmap_node.outputs['Color'], normalmap_node.inputs['Color'])
+            self.connect_nodes(normalmap_node.outputs['Normal'], shader.inputs['Normal'])
 
     def load_texture(self, texture_name: str, texture_path: TinyPath):
         image = check_texture_cache(texture_path / texture_name)

--- a/blender_bindings/models/glm2_6/import_glm.py
+++ b/blender_bindings/models/glm2_6/import_glm.py
@@ -111,7 +111,7 @@ def import_model(name: str, mdl_buffer: Buffer, options: ModelOptions, content_m
             material_params = material_definitions[material_name]
         else:
             material_params = {'textures': [{"map": material_name}]}
-        if mat.get('source1_loaded'):
+        if mat.get('source_loaded'):
             continue
         loader = IdTech3Shader(content_manager)
         loader.create_nodes(mat, material_params)

--- a/blender_bindings/models/md3_15/__init__.py
+++ b/blender_bindings/models/md3_15/__init__.py
@@ -67,7 +67,7 @@ def import_md3_15(model_path: TinyPath, buffer: Buffer,
         mat = get_or_create_material(TinyPath(material_name).stem, material_name)
         add_material(mat, model_object)
 
-        if mat.get('source1_loaded'):
+        if mat.get('source_loaded'):
             logger.debug(
                 f'Skipping loading of {material_name} as it already loaded')
             continue
@@ -82,7 +82,7 @@ def import_md3_15(model_path: TinyPath, buffer: Buffer,
         loader.create_nodes(mat, material_params)
 
         # if ".tga" in material_name or ".png" in material_name or ".jpg" in material_name or ".jpeg" in material_name:
-        #     mat['source1_loaded'] = True
+        #     mat['source_loaded'] = True
         #     loader = IdTech3Shader(content_manager)
         #     material_name = TinyPath(material_name).with_suffix("").as_posix()
         #     loader.create_nodes(mat, {'textures': [{"map":material_name}]})

--- a/blender_bindings/models/mdl2531/import_mdl.py
+++ b/blender_bindings/models/mdl2531/import_mdl.py
@@ -286,7 +286,7 @@ def import_materials(content_manager: ContentManager, mdl, use_bvlg=False):
             continue
         mat = get_or_create_material(material.name, material_path.as_posix())
 
-        if mat.get('source1_loaded', False):
+        if mat.get('source_loaded', False):
             logger.info(f'Skipping loading of {mat} as it already loaded')
             continue
 

--- a/blender_bindings/models/mdl36/import_mdl.py
+++ b/blender_bindings/models/mdl36/import_mdl.py
@@ -267,7 +267,7 @@ def import_materials(content_manager: ContentManager, mdl, use_bvlg=False):
             continue
         mat = get_or_create_material(material.name, material_path.as_posix())
 
-        if mat.get('source1_loaded', False):
+        if mat.get('source_loaded', False):
             logger.info(f'Skipping loading of {mat} as it already loaded')
             continue
 

--- a/blender_bindings/source1/bsp/import_bsp.py
+++ b/blender_bindings/source1/bsp/import_bsp.py
@@ -193,7 +193,7 @@ def import_materials(bsp: VBSPFile, content_manager: ContentManager, settings: S
 
             mat = get_or_create_material(path_stem(tmp), tmp)
 
-            if mat.get('source1_loaded'):
+            if mat.get('source_loaded'):
                 logger.debug(
                     f'Skipping loading of {tmp} as it already loaded')
                 continue
@@ -221,7 +221,7 @@ def import_materials(bsp: VBSPFile, content_manager: ContentManager, settings: S
             material_name = shaders.name
             mat = get_or_create_material(path_stem(material_name), material_name)
 
-            if mat.get('source1_loaded'):
+            if mat.get('source_loaded'):
                 logger.debug(
                     f'Skipping loading of {material_name} as it already loaded')
                 continue
@@ -231,7 +231,7 @@ def import_materials(bsp: VBSPFile, content_manager: ContentManager, settings: S
                 material_params = material_definitions[material_name]
             else:
                 material_params = {'textures': [{"map": material_name}]}
-            if mat.get('source1_loaded'):
+            if mat.get('source_loaded'):
                 logger.debug(
                     f'Skipping loading of {material_name} as it already loaded')
                 continue
@@ -253,7 +253,7 @@ def import_materials(bsp: VBSPFile, content_manager: ContentManager, settings: S
                 material_params = material_definitions[material_name]
             else:
                 material_params = {'textures': [{"map": material_name}]}
-            if mat.get('source1_loaded'):
+            if mat.get('source_loaded'):
                 logger.debug(
                     f'Skipping loading of {material_name} as it already loaded')
                 continue

--- a/library/utils/path_utilities.py
+++ b/library/utils/path_utilities.py
@@ -3,6 +3,10 @@ import platform
 from typing import Optional
 
 from SourceIO.library.utils import TinyPath
+from SourceIO.logger import SourceLogMan
+
+_log_manager = SourceLogMan()
+_logger = _log_manager.get_logger('PathUtilities')
 
 
 def pop_path_back(path: TinyPath):
@@ -120,5 +124,6 @@ def collect_full_material_names(material_names: list[str], material_search_paths
                 full_mat_names[material_name] = (material_path / material_name).as_posix().lstrip('/')
     for material_name in material_names:
         if material_name not in full_mat_names:
+            _logger.warn(f'Material VMT not found for "{material_name}" in any search path')
             full_mat_names[material_name] = material_name
     return full_mat_names


### PR DESCRIPTION
fixes an issue where models would sometimes import with fully white materials even though the material files exist.

fully tested with gmod models specifically, fixes import problems for me and the modelers I work with. 
(windows and mac tested)