### PR TITLE
decal_scale = 1 and default infodecal size = 64x64

### DIFF
--- a/blender_bindings/source1/bsp/entities/base_entity_handler.py
+++ b/blender_bindings/source1/bsp/entities/base_entity_handler.py
@@ -744,7 +744,6 @@ class BaseEntityHandler(AbstractEntityHandler):
         decal_scale = 1
         mat = None
         material_file = self.content_manager.find_file(material_path)
-        decal_scale = 0.25
         if material_file:
             material_name = strip_patch_coordinates.sub("", material_name)
             mat = get_or_create_material(path_stem(material_name), material_name)


### PR DESCRIPTION
fix: decal_scale is now set to 1, which fixes Counter-Strike: Source spraypaint decals. change: default infodecal size is now 64x64, was 128x128