### PR TITLE
Fix: allow lowercase 'position' and 'normal' fields to be accessed in VMDLs

### DIFF
--- a/blender_bindings/source2/vmdl_loader.py
+++ b/blender_bindings/source2/vmdl_loader.py
@@ -542,11 +542,18 @@ def import_drawcall(content_manager: ContentManager, import_context: ImportConte
     if tint is not None:
         mesh_obj.color = list(tint) + [1.0]
 
-    positions = used_vertices['POSITION'] * import_context.scale
+    if 'position' in used_vertices.dtype.names:
+        positions = used_vertices['position'] * import_context.scale
+    else:
+        positions = used_vertices['POSITION'] * import_context.scale
 
     normals = None
-    if vertex_buffer.has_attribute('NORMAL'):
+    if vertex_buffer.has_attribute('normal'):
+        normals = used_vertices['normal']
+    elif vertex_buffer.has_attribute('NORMAL'):
         normals = used_vertices['NORMAL']
+
+    if normals is not None:
         if use_compressed_normals(draw_call):
             if normals.dtype == np.uint32:
                 normals = convert_normals_2(normals)


### PR DESCRIPTION
Some VMDLs for the Source 2 engine come with lowercase 'normal' and 'position' fields in their vertices. This tweak just makes it so vmdl_loader.py can load them without a runtime exception. Found the issue on some skin mods for Deadlock and verified that afterwards I was able to import them into Blender.