### PR TITLE
Prefix log files with a period

### DIFF
--- a/blender_bindings/utils/logging_impl.py
+++ b/blender_bindings/utils/logging_impl.py
@@ -70,7 +70,7 @@ class BPYLogger:
     def _add_bpy_file_logger(self):
         if bpy.data.__class__.__name__ == "_RestrictData":
             return
-        self._bpy_file, new = get_log_file(self.name)
+        self._bpy_file, new = get_log_file('.' + self.name)
         if self._bpy_logger is not None:
             self._bpy_logger.stream = self._bpy_file
         if new:


### PR DESCRIPTION
Importing a MDL creates a bunch of text data blocks, which can not be disabled.

By prefixing their name with a period, it avoids showing these logs in the Text Editor dropdown
unless user explicitly types `.` into the search, or they have hidden datablocks enabled in the [user preferences](https://docs.blender.org/manual/en/latest/interface/controls/templates/data_block.html).

Alternative solution, if discoverability of these logs is important for bug reports: Prefix all of them with one common prefix, like `SourceIO MDL Loader`, so you can scroll past them in one chunk instead of being mixed with various other texts.