### PR TITLE
Fix PHY collision mesh importing flipped

### DIFF
--- a/library/models/phy/phy.py
+++ b/library/models/phy/phy.py
@@ -151,11 +151,6 @@ class CollisionModel:
             vertex_data = np.frombuffer(buffer.read(4 * 4 * vertex_count), np.float32).copy()
             vertex_data = vertex_data.reshape((-1, 4))[:, :3]
 
-            y = vertex_data[:, 1].copy()
-            z = vertex_data[:, 2].copy()
-            vertex_data[:, 1] = z
-            vertex_data[:, 2] = y
-
         return vertex_data
 
 


### PR DESCRIPTION
## Description

I changed PHY collision vertex decoding to preserve the Source1 XYZ coordinate order. Previously the decoder exchanged Y and Z before mesh creation, mirroring the collision mesh against the visual model.

Fixes #290

## Why

Collision geometry needs the same coordinate order as the visual model it represents. The mdl49 and mdl52 visual importers already pass decoded VVD coordinates straight into `Mesh.from_pydata`, so the PHY-only swap was the odd one out.

## Verification

- before, on current `master`: raw PHY vertex floats `1, 2, 3` fed through `CollisionModel.get_vertex_data` came back `1, 3, 2` with lateral and vertical swapped
- after: the same input decodes `1, 2, 3`, matching the order the visual mesh importers use
- `python3 -m compileall -q library/models/phy/phy.py`
